### PR TITLE
feat: add hero live audio player with HLS support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "hls.js": "^1.5.18",
     "i18next": "^23.11.5",
     "i18next-browser-languagedetector": "^7.2.0",
     "react": "^18.3.1",

--- a/src/assets/data/nowPlaying.mock.json
+++ b/src/assets/data/nowPlaying.mock.json
@@ -1,0 +1,6 @@
+{
+  "title": "Chill Synthwave Session",
+  "artist": "DJ Adamowo",
+  "artwork": "/images/Icon.jpg",
+  "startedAt": "2024-01-01T00:00:00Z"
+}

--- a/src/components/AudioViz.tsx
+++ b/src/components/AudioViz.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef } from 'react';
+
+interface AudioVizProps {
+  audio: HTMLAudioElement | null;
+  active: boolean;
+  ariaLabel: string;
+}
+
+export function AudioViz({ audio, active, ariaLabel }: AudioVizProps): JSX.Element {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const animationRef = useRef<number>();
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const sourceRef = useRef<MediaElementAudioSourceNode | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    const dpr = window.devicePixelRatio || 1;
+    const width = canvas.clientWidth * dpr;
+    const height = canvas.clientHeight * dpr;
+    if (canvas.width !== width || canvas.height !== height) {
+      canvas.width = width;
+      canvas.height = height;
+    }
+  });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !audio || !active) {
+      if (!active && audioContextRef.current?.state === 'running') {
+        void audioContextRef.current.suspend().catch(() => undefined);
+      }
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+        animationRef.current = undefined;
+      }
+      return;
+    }
+
+    let isMounted = true;
+
+    const ensureContext = async (): Promise<void> => {
+      if (!audioContextRef.current) {
+        try {
+          const context = new AudioContext();
+          const source = context.createMediaElementSource(audio);
+          const analyser = context.createAnalyser();
+          analyser.fftSize = 64;
+          source.connect(analyser);
+          analyser.connect(context.destination);
+          audioContextRef.current = context;
+          analyserRef.current = analyser;
+          sourceRef.current = source;
+        } catch (error) {
+          console.warn('Audio visualizer could not initialise', error);
+          return;
+        }
+      }
+
+      const context = audioContextRef.current;
+      const analyser = analyserRef.current;
+
+      if (!context || !analyser) {
+        return;
+      }
+
+      if (context.state === 'suspended') {
+        try {
+          await context.resume();
+        } catch (error) {
+          console.warn('AudioContext resume failed', error);
+        }
+      }
+
+      const canvasContext = canvas.getContext('2d');
+      if (!canvasContext) {
+        return;
+      }
+
+      const bufferLength = analyser.frequencyBinCount;
+      const dataArray = new Uint8Array(bufferLength);
+
+      const draw = (): void => {
+        if (!isMounted) {
+          return;
+        }
+
+        analyser.getByteFrequencyData(dataArray);
+
+        const { width, height } = canvas;
+        canvasContext.clearRect(0, 0, width, height);
+
+        const barWidth = width / bufferLength;
+        for (let i = 0; i < bufferLength; i += 1) {
+          const value = dataArray[i] / 255;
+          const barHeight = value * height;
+          const x = i * barWidth;
+          canvasContext.fillStyle = '#ff6b35';
+          canvasContext.fillRect(x, height - barHeight, barWidth * 0.7, barHeight);
+        }
+
+        animationRef.current = requestAnimationFrame(draw);
+      };
+
+      draw();
+    };
+
+    void ensureContext();
+
+    return () => {
+      isMounted = false;
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+        animationRef.current = undefined;
+      }
+    };
+  }, [active, audio]);
+
+  useEffect(() => () => {
+    if (animationRef.current) {
+      cancelAnimationFrame(animationRef.current);
+    }
+
+    if (sourceRef.current) {
+      sourceRef.current.disconnect();
+      sourceRef.current = null;
+    }
+
+    if (analyserRef.current) {
+      analyserRef.current.disconnect();
+      analyserRef.current = null;
+    }
+
+    if (audioContextRef.current) {
+      void audioContextRef.current.close();
+      audioContextRef.current = null;
+    }
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="h-20 w-full rounded-lg bg-base-900/60"
+      role="img"
+      aria-label={ariaLabel}
+    />
+  );
+}

--- a/src/components/HeroPlayer.tsx
+++ b/src/components/HeroPlayer.tsx
@@ -1,0 +1,391 @@
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
+import clsx from 'clsx';
+import Hls from 'hls.js';
+import { useTranslation } from 'react-i18next';
+import { AudioViz } from './AudioViz';
+import type { HlsClient } from '../lib/hlsClient';
+import { MAX_RECONNECT_ATTEMPTS, createHlsClient } from '../lib/hlsClient';
+import {
+  FALLBACK_NOW_PLAYING,
+  NowPlaying,
+  fetchNowPlaying
+} from '../lib/nowPlaying';
+import { usePlayerStore } from '../state/player';
+
+const POLLING_INTERVAL = 15_000;
+
+export function HeroPlayer(): JSX.Element {
+  const { t } = useTranslation();
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const hlsRef = useRef<HlsClient | null>(null);
+  const [nowPlaying, setNowPlaying] = useState<NowPlaying>(FALLBACK_NOW_PLAYING);
+
+  const {
+    playing,
+    volume,
+    muted,
+    status,
+    error,
+    reconnectCount,
+    src,
+    setPlaying,
+    setVolume,
+    setMuted,
+    setStatus,
+    setError,
+    setReconnectCount,
+    resetReconnect
+  } = usePlayerStore((state) => ({
+    playing: state.playing,
+    volume: state.volume,
+    muted: state.muted,
+    status: state.status,
+    error: state.error,
+    reconnectCount: state.reconnectCount,
+    src: state.src,
+    setPlaying: state.setPlaying,
+    setVolume: state.setVolume,
+    setMuted: state.setMuted,
+    setStatus: state.setStatus,
+    setError: state.setError,
+    setReconnectCount: state.setReconnectCount,
+    resetReconnect: state.resetReconnect
+  }));
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const poll = async (): Promise<void> => {
+      const metadata = await fetchNowPlaying();
+      if (isMounted) {
+        setNowPlaying(metadata);
+      }
+    };
+
+    void poll();
+    const intervalId = window.setInterval(poll, POLLING_INTERVAL);
+
+    return () => {
+      isMounted = false;
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio || !src) {
+      return;
+    }
+
+    if (Hls.isSupported()) {
+      const client = createHlsClient(audio, src, {
+        onReady: () => {
+          setStatus('buffering');
+        },
+        onReconnectAttempt: (attempt) => {
+          setStatus('reconnecting');
+          setReconnectCount(attempt);
+          setError(null);
+        },
+        onReconnectSuccess: () => {
+          setStatus('buffering');
+          resetReconnect();
+        },
+        onError: (message) => {
+          setStatus('error');
+          setError(message);
+          setPlaying(false);
+        }
+      });
+
+      hlsRef.current = client;
+
+      return () => {
+        client.destroy();
+        hlsRef.current = null;
+      };
+    }
+
+    if (audio.canPlayType('application/vnd.apple.mpegurl')) {
+      audio.src = src;
+      setStatus('buffering');
+      return () => {
+        audio.removeAttribute('src');
+      };
+    }
+
+    audio.src = src;
+    setStatus('buffering');
+
+    return () => {
+      audio.removeAttribute('src');
+    };
+  }, [resetReconnect, setError, setPlaying, setReconnectCount, setStatus, src]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    audio.volume = muted ? 0 : volume;
+    audio.muted = muted;
+  }, [muted, volume]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    const handlePlay = (): void => {
+      setStatus('playing');
+      setPlaying(true);
+      setError(null);
+    };
+
+    const handlePause = (): void => {
+      setPlaying(false);
+      if (!audio.error) {
+        setStatus('idle');
+      }
+    };
+
+    const handleWaiting = (): void => {
+      setStatus('buffering');
+    };
+
+    const handleError = (): void => {
+      const mediaError = audio.error
+        ? `Media error: ${audio.error.code}`
+        : 'Playback error';
+      setError(mediaError);
+      setStatus('error');
+      setPlaying(false);
+    };
+
+    const handleEnded = (): void => {
+      setPlaying(false);
+      setStatus('idle');
+    };
+
+    audio.addEventListener('play', handlePlay);
+    audio.addEventListener('playing', handlePlay);
+    audio.addEventListener('pause', handlePause);
+    audio.addEventListener('waiting', handleWaiting);
+    audio.addEventListener('error', handleError);
+    audio.addEventListener('ended', handleEnded);
+
+    return () => {
+      audio.removeEventListener('play', handlePlay);
+      audio.removeEventListener('playing', handlePlay);
+      audio.removeEventListener('pause', handlePause);
+      audio.removeEventListener('waiting', handleWaiting);
+      audio.removeEventListener('error', handleError);
+      audio.removeEventListener('ended', handleEnded);
+    };
+  }, [setError, setPlaying, setStatus]);
+
+  const statusLabel = useMemo(() => {
+    switch (status) {
+      case 'playing':
+        return t('player.live');
+      case 'buffering':
+        return t('player.buffering');
+      case 'reconnecting':
+        return t('player.reconnecting', {
+          attempt: reconnectCount,
+          max: MAX_RECONNECT_ATTEMPTS
+        });
+      case 'error':
+        return t('player.error');
+      default:
+        return t('player.idle');
+    }
+  }, [reconnectCount, status, t]);
+
+  const handleTogglePlay = async (): Promise<void> => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    if (playing) {
+      audio.pause();
+      setPlaying(false);
+      setStatus('idle');
+      return;
+    }
+
+    try {
+      resetReconnect();
+      setError(null);
+      setStatus('buffering');
+      await audio.play();
+      setPlaying(true);
+    } catch (err) {
+      setStatus('error');
+      setError(err instanceof Error ? err.message : 'Playback failed');
+    }
+  };
+
+  const handleVolumeChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    const value = Number(event.target.value);
+    setVolume(value);
+    const audio = audioRef.current;
+    if (audio) {
+      audio.volume = value;
+    }
+    if (value === 0) {
+      setMuted(true);
+    } else if (muted) {
+      setMuted(false);
+      if (audio) {
+        audio.muted = false;
+      }
+    }
+  };
+
+  const handleMuteToggle = (): void => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    const nextMuted = !muted;
+    setMuted(nextMuted);
+    audio.muted = nextMuted;
+    if (!nextMuted && audio.volume === 0) {
+      audio.volume = 0.5;
+      setVolume(0.5);
+    }
+  };
+
+  const handleRetry = (): void => {
+    setError(null);
+    setStatus('buffering');
+    resetReconnect();
+    if (hlsRef.current) {
+      hlsRef.current.retry();
+      return;
+    }
+
+    const audio = audioRef.current;
+    if (!audio || !src) {
+      return;
+    }
+
+    audio.load();
+    void audio.play().catch(() => {
+      setStatus('error');
+    });
+  };
+
+  return (
+    <section
+      className="rounded-3xl bg-gradient-to-br from-[#0a0e27] to-[#1a1f3a] p-6 text-base-100 shadow-xl sm:p-10"
+      role="region"
+      aria-label={t('player.regionLabel')}
+    >
+      <div className="grid gap-6 lg:grid-cols-[280px,1fr] lg:items-center">
+        <div className="relative overflow-hidden rounded-3xl bg-base-900/50">
+          <img
+            src={nowPlaying.artwork}
+            alt={t('player.artworkAlt', { title: nowPlaying.title, artist: nowPlaying.artist })}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+          <span className="absolute left-4 top-4 inline-flex items-center gap-2 rounded-full bg-accent-500/90 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-base-950">
+            <span className="h-2 w-2 rounded-full bg-base-950" aria-hidden="true" />
+            {t('player.live')}
+          </span>
+        </div>
+        <div className="space-y-6">
+          <div className="space-y-2">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-accent-300">
+              {t('player.nowPlaying')}
+            </p>
+            <h2 className="text-3xl font-bold text-base-50 sm:text-4xl">{nowPlaying.title}</h2>
+            <p className="text-base-200">{nowPlaying.artist}</p>
+          </div>
+          <AudioViz
+            audio={audioRef.current}
+            active={playing}
+            ariaLabel={t('player.visualizerAria')}
+          />
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={handleTogglePlay}
+                className={clsx(
+                  'rounded-full px-6 py-3 text-sm font-semibold uppercase tracking-wide transition-colors',
+                  playing
+                    ? 'bg-accent-500 text-base-950 hover:bg-accent-400'
+                    : 'bg-accent-400 text-base-950 hover:bg-accent-300'
+                )}
+                aria-pressed={playing}
+                aria-label={playing ? t('player.pause') : t('player.play')}
+              >
+                {playing ? t('player.pause') : t('player.play')}
+              </button>
+              <button
+                type="button"
+                onClick={handleMuteToggle}
+                className="rounded-full border border-base-700 px-4 py-2 text-sm text-base-100 transition-colors hover:border-accent-400 hover:text-accent-200"
+                aria-pressed={muted}
+                aria-label={muted ? t('player.unmute') : t('player.mute')}
+              >
+                {muted ? t('player.unmute') : t('player.mute')}
+              </button>
+              <span className="rounded-full border border-base-800 px-3 py-1 text-xs uppercase tracking-wide text-base-200">
+                {t('player.quality_128kbps')}
+              </span>
+            </div>
+            <label className="flex w-full flex-col gap-2 text-xs font-semibold uppercase tracking-wide text-base-200 lg:w-64">
+              {t('player.volume')}
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.01"
+                value={muted ? 0 : volume}
+                onChange={handleVolumeChange}
+                className="h-2 w-full cursor-pointer appearance-none rounded-full bg-base-800 accent-accent-400"
+                aria-valuemin={0}
+                aria-valuemax={1}
+                aria-valuenow={Number((muted ? 0 : volume).toFixed(2))}
+                aria-label={t('player.volume')}
+              />
+            </label>
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-sm text-base-200">
+            <p role="status" aria-live="polite" className="font-semibold text-base-100">
+              {statusLabel}
+            </p>
+            {status === 'error' && (
+              <>
+                <span className="text-base-400" role="alert">
+                  {error}
+                </span>
+                <button
+                  type="button"
+                  onClick={handleRetry}
+                  className="rounded-full border border-accent-400 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-accent-200 transition-colors hover:bg-accent-400/10"
+                >
+                  {t('player.retry')}
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+      <audio
+        ref={audioRef}
+        preload="none"
+        crossOrigin="anonymous"
+        aria-hidden="true"
+      />
+    </section>
+  );
+}

--- a/src/components/__tests__/HeroPlayer.test.tsx
+++ b/src/components/__tests__/HeroPlayer.test.tsx
@@ -1,0 +1,179 @@
+import { fireEvent, render, screen, waitFor, act } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../../i18n';
+import { HeroPlayer } from '../HeroPlayer';
+import { usePlayerStore } from '../../state/player';
+
+vi.mock('hls.js', () => ({
+  default: {
+    isSupported: () => true
+  }
+}));
+
+const defaultNowPlaying = {
+  title: 'Mock Track',
+  artist: 'Mock Artist',
+  artwork: '/mock.jpg'
+};
+
+let capturedHlsOptions: Record<string, ((...args: any[]) => void) | undefined> | undefined;
+
+const mockFetchNowPlaying = vi.fn(() => Promise.resolve(defaultNowPlaying));
+const mockRetry = vi.fn();
+const mockCreateHlsClient = vi.fn((_: unknown, __: unknown, options: Record<string, any>) => {
+  capturedHlsOptions = options as typeof capturedHlsOptions;
+  return {
+    destroy: vi.fn(),
+    retry: mockRetry
+  };
+});
+
+vi.mock('../../lib/nowPlaying', () => ({
+  fetchNowPlaying: mockFetchNowPlaying,
+  FALLBACK_NOW_PLAYING: defaultNowPlaying
+}));
+
+vi.mock('../../lib/hlsClient', () => ({
+  MAX_RECONNECT_ATTEMPTS: 5,
+  createHlsClient: mockCreateHlsClient
+}));
+
+const renderPlayer = (): void => {
+  render(
+    <I18nextProvider i18n={i18n}>
+      <HeroPlayer />
+    </I18nextProvider>
+  );
+};
+
+const resetPlayerStore = (): void => {
+  usePlayerStore.setState({
+    playing: false,
+    volume: 1,
+    muted: false,
+    src: 'https://example.com/stream.m3u8',
+    status: 'idle',
+    error: null,
+    reconnectCount: 0
+  });
+};
+
+beforeAll(() => {
+  const playSpy = vi
+    .spyOn(window.HTMLMediaElement.prototype, 'play')
+    .mockImplementation(function mockPlay(this: HTMLMediaElement) {
+      this.dispatchEvent(new Event('play'));
+      this.dispatchEvent(new Event('playing'));
+      return Promise.resolve();
+    });
+
+  const pauseSpy = vi
+    .spyOn(window.HTMLMediaElement.prototype, 'pause')
+    .mockImplementation(function mockPause(this: HTMLMediaElement) {
+      this.dispatchEvent(new Event('pause'));
+    });
+
+  const loadSpy = vi
+    .spyOn(window.HTMLMediaElement.prototype, 'load')
+    .mockImplementation(() => undefined);
+
+  // Silence unused variable lint warnings
+  if (!playSpy || !pauseSpy || !loadSpy) {
+    throw new Error('Failed to mock media element methods');
+  }
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetPlayerStore();
+  capturedHlsOptions = undefined;
+  mockFetchNowPlaying.mockResolvedValue(defaultNowPlaying);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('HeroPlayer', () => {
+  it('renders now playing info and toggles play/pause state', async () => {
+    renderPlayer();
+
+    await waitFor(() => expect(mockCreateHlsClient).toHaveBeenCalled());
+
+    const playButton = await screen.findByRole('button', { name: /play/i });
+
+    expect(playButton).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(playButton);
+
+    await waitFor(() => expect(playButton).toHaveAttribute('aria-pressed', 'true'));
+
+    fireEvent.click(playButton);
+
+    await waitFor(() => expect(playButton).toHaveAttribute('aria-pressed', 'false'));
+  });
+
+  it('updates volume slider and mute button aria attributes', async () => {
+    renderPlayer();
+
+    const volumeSlider = await screen.findByRole('slider', { name: /volume/i });
+    fireEvent.change(volumeSlider, { target: { value: '0.5' } });
+
+    await waitFor(() =>
+      expect(volumeSlider).toHaveAttribute('aria-valuenow', expect.stringContaining('0.5'))
+    );
+
+    const muteButton = screen.getByRole('button', { name: /mute/i });
+    fireEvent.click(muteButton);
+
+    await waitFor(() => expect(muteButton).toHaveAttribute('aria-pressed', 'true'));
+
+    fireEvent.click(muteButton);
+    await waitFor(() => expect(muteButton).toHaveAttribute('aria-pressed', 'false'));
+  });
+
+  it('shows error message and retry option on HLS error', async () => {
+    renderPlayer();
+
+    await waitFor(() => expect(mockCreateHlsClient).toHaveBeenCalled());
+    expect(capturedHlsOptions).toBeDefined();
+
+    act(() => {
+      capturedHlsOptions?.onReconnectAttempt?.(2, 5);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent('Reconnecting (2/5)…')
+    );
+
+    act(() => {
+      capturedHlsOptions?.onError?.('Network down');
+    });
+
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Playback error'));
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Network down'));
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(mockRetry).toHaveBeenCalled();
+  });
+
+  it('refreshes now playing metadata on interval', async () => {
+    vi.useFakeTimers();
+
+    const first = { title: 'Track One', artist: 'Artist One', artwork: '/one.jpg' };
+    const second = { title: 'Track Two', artist: 'Artist Two', artwork: '/two.jpg' };
+
+    mockFetchNowPlaying.mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+
+    renderPlayer();
+
+    expect(await screen.findByText('Track One')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(15_000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.getByText('Track Two')).toBeInTheDocument());
+  });
+});

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -40,5 +40,23 @@
       "dark": "Dark mode"
     },
     "language": "Language"
+  },
+  "player": {
+    "play": "Play",
+    "pause": "Pause",
+    "live": "Live",
+    "buffering": "Buffering…",
+    "reconnecting": "Reconnecting ({{attempt}}/{{max}})…",
+    "error": "Playback error",
+    "idle": "Ready",
+    "retry": "Retry",
+    "volume": "Volume",
+    "mute": "Mute",
+    "unmute": "Unmute",
+    "quality_128kbps": "128 kbps",
+    "nowPlaying": "Now Playing",
+    "regionLabel": "Live radio player",
+    "artworkAlt": "Cover art for {{title}} by {{artist}}",
+    "visualizerAria": "Audio spectrum visualisation"
   }
 }

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -40,5 +40,23 @@
       "dark": "Donkere modus"
     },
     "language": "Taal"
+  },
+  "player": {
+    "play": "Afspelen",
+    "pause": "Pauzeren",
+    "live": "Live",
+    "buffering": "Bufferen…",
+    "reconnecting": "Opnieuw verbinden ({{attempt}}/{{max}})…",
+    "error": "Afspeelfout",
+    "idle": "Gereed",
+    "retry": "Opnieuw proberen",
+    "volume": "Volume",
+    "mute": "Dempen",
+    "unmute": "Dempen uit",
+    "quality_128kbps": "128 kbps",
+    "nowPlaying": "Nu speelt",
+    "regionLabel": "Live radioplayer",
+    "artworkAlt": "Albumhoes voor {{title}} van {{artist}}",
+    "visualizerAria": "Audiospectrum visualisatie"
   }
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -40,5 +40,23 @@
       "dark": "Tryb ciemny"
     },
     "language": "Język"
+  },
+  "player": {
+    "play": "Odtwórz",
+    "pause": "Pauza",
+    "live": "Na żywo",
+    "buffering": "Buforowanie…",
+    "reconnecting": "Ponowne łączenie ({{attempt}}/{{max}})…",
+    "error": "Błąd odtwarzania",
+    "idle": "Gotowy",
+    "retry": "Spróbuj ponownie",
+    "volume": "Głośność",
+    "mute": "Wycisz",
+    "unmute": "Włącz dźwięk",
+    "quality_128kbps": "128 kb/s",
+    "nowPlaying": "Teraz gramy",
+    "regionLabel": "Odtwarzacz radia na żywo",
+    "artworkAlt": "Okładka: {{title}} — {{artist}}",
+    "visualizerAria": "Wizualizacja widma audio"
   }
 }

--- a/src/lib/hlsClient.ts
+++ b/src/lib/hlsClient.ts
@@ -1,0 +1,159 @@
+import Hls from 'hls.js';
+
+interface HlsClientOptions {
+  onReady?: () => void;
+  onError?: (message: string) => void;
+  onReconnectAttempt?: (attempt: number, maxAttempts: number) => void;
+  onReconnectSuccess?: () => void;
+  maxRetries?: number;
+}
+
+export interface HlsClient {
+  destroy: () => void;
+  retry: () => void;
+}
+
+export const MAX_RECONNECT_ATTEMPTS = 5;
+
+export function createHlsClient(
+  audio: HTMLAudioElement,
+  src: string,
+  options: HlsClientOptions = {}
+): HlsClient {
+  const {
+    onReady,
+    onError,
+    onReconnectAttempt,
+    onReconnectSuccess,
+    maxRetries = MAX_RECONNECT_ATTEMPTS
+  } = options;
+
+  const hls = new Hls({ enableWorker: true, lowLatencyMode: true });
+  let destroyed = false;
+  let retries = 0;
+  let retryTimeout: number | undefined;
+
+  const clearRetryTimeout = (): void => {
+    if (retryTimeout) {
+      window.clearTimeout(retryTimeout);
+      retryTimeout = undefined;
+    }
+  };
+
+  const attach = (): void => {
+    if (destroyed) {
+      return;
+    }
+
+    if (audio.src) {
+      audio.removeAttribute('src');
+      audio.load();
+    }
+
+    hls.attachMedia(audio);
+  };
+
+  const scheduleRetry = (): void => {
+    if (destroyed) {
+      return;
+    }
+
+    if (retries >= maxRetries) {
+      onError?.('Maximum reconnect attempts reached');
+      return;
+    }
+
+    retries += 1;
+    onReconnectAttempt?.(retries, maxRetries);
+
+    const delay = Math.min(8000, 1000 * 2 ** (retries - 1));
+    clearRetryTimeout();
+    retryTimeout = window.setTimeout(() => {
+      if (destroyed) {
+        return;
+      }
+
+      hls.stopLoad();
+      hls.detachMedia();
+      attach();
+    }, delay);
+  };
+
+  hls.on(Hls.Events.MEDIA_ATTACHED, () => {
+    if (destroyed) {
+      return;
+    }
+
+    hls.loadSource(src);
+  });
+
+  hls.on(Hls.Events.MANIFEST_PARSED, () => {
+    if (destroyed) {
+      return;
+    }
+
+    retries = 0;
+    clearRetryTimeout();
+    onReady?.();
+  });
+
+  hls.on(Hls.Events.LEVEL_LOADED, () => {
+    if (destroyed) {
+      return;
+    }
+
+    if (retries > 0) {
+      retries = 0;
+      onReconnectSuccess?.();
+    }
+  });
+
+  hls.on(Hls.Events.ERROR, (_, data) => {
+    if (destroyed) {
+      return;
+    }
+
+    if (data.fatal) {
+      switch (data.type) {
+        case Hls.ErrorTypes.NETWORK_ERROR:
+          scheduleRetry();
+          break;
+        case Hls.ErrorTypes.MEDIA_ERROR:
+          hls.recoverMediaError();
+          break;
+        default:
+          scheduleRetry();
+          break;
+      }
+    } else if (data.type === Hls.ErrorTypes.NETWORK_ERROR) {
+      scheduleRetry();
+    }
+
+    if (data.fatal && retries >= maxRetries) {
+      const message = typeof data.error === 'string' ? data.error : data.details;
+      onError?.(message ?? 'Unknown HLS error');
+    }
+  });
+
+  attach();
+
+  return {
+    destroy: () => {
+      destroyed = true;
+      clearRetryTimeout();
+      hls.destroy();
+    },
+    retry: () => {
+      if (destroyed) {
+        return;
+      }
+
+      retries = 0;
+      onReconnectAttempt?.(1, maxRetries);
+      clearRetryTimeout();
+      hls.stopLoad();
+      hls.detachMedia();
+      attach();
+    }
+  };
+}

--- a/src/lib/nowPlaying.ts
+++ b/src/lib/nowPlaying.ts
@@ -1,0 +1,69 @@
+export interface NowPlaying {
+  title: string;
+  artist: string;
+  artwork: string;
+  startedAt?: string;
+}
+
+const FALLBACK_NOW_PLAYING: NowPlaying = {
+  title: 'Radio Adamowo',
+  artist: 'Live',
+  artwork: '/images/Icon.jpg'
+};
+
+const METADATA_URL = import.meta.env.VITE_METADATA_URL as string | undefined;
+
+function parseNowPlaying(candidate: unknown): NowPlaying {
+  if (!candidate || typeof candidate !== 'object') {
+    return FALLBACK_NOW_PLAYING;
+  }
+
+  const record = candidate as Record<string, unknown>;
+
+  const title = typeof record.title === 'string' && record.title.trim()
+    ? record.title.trim()
+    : FALLBACK_NOW_PLAYING.title;
+
+  const artist = typeof record.artist === 'string' && record.artist.trim()
+    ? record.artist.trim()
+    : FALLBACK_NOW_PLAYING.artist;
+
+  const artwork = typeof record.artwork === 'string' && record.artwork.trim()
+    ? record.artwork.trim()
+    : FALLBACK_NOW_PLAYING.artwork;
+
+  const startedAt = typeof record.startedAt === 'string' ? record.startedAt : undefined;
+
+  return {
+    title,
+    artist,
+    artwork,
+    startedAt
+  };
+}
+
+export async function fetchNowPlaying(): Promise<NowPlaying> {
+  try {
+    if (METADATA_URL) {
+      const response = await fetch(METADATA_URL, {
+        headers: { Accept: 'application/json' },
+        cache: 'no-store'
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch metadata: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return parseNowPlaying(data);
+    }
+
+    const module = await import('../assets/data/nowPlaying.mock.json');
+    return parseNowPlaying(module.default);
+  } catch (error) {
+    console.error('Failed to load Now Playing metadata', error);
+    return FALLBACK_NOW_PLAYING;
+  }
+}
+
+export { FALLBACK_NOW_PLAYING };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,12 +1,16 @@
 import { useTranslation } from 'react-i18next';
+import { HeroPlayer } from '../components/HeroPlayer';
 
 export default function Home(): JSX.Element {
   const { t } = useTranslation();
 
   return (
-    <section className="space-y-4">
-      <h1 className="text-3xl font-bold text-base-50 sm:text-4xl">{t('pages.home.title')}</h1>
-      <p className="max-w-2xl text-base-200">{t('pages.home.lead')}</p>
-    </section>
+    <div className="space-y-12">
+      <HeroPlayer />
+      <section className="space-y-4">
+        <h1 className="text-3xl font-bold text-base-50 sm:text-4xl">{t('pages.home.title')}</h1>
+        <p className="max-w-2xl text-base-200">{t('pages.home.lead')}</p>
+      </section>
+    </div>
   );
 }

--- a/src/state/player.ts
+++ b/src/state/player.ts
@@ -1,21 +1,41 @@
 import { create } from 'zustand';
 
-export type StreamQuality = '128kbps';
+export type PlayerStatus = 'idle' | 'buffering' | 'playing' | 'reconnecting' | 'error';
 
-interface PlayerState {
-  isPlaying: boolean;
+export interface PlayerState {
+  playing: boolean;
   volume: number;
-  quality: StreamQuality;
-  setPlaying: (isPlaying: boolean) => void;
+  muted: boolean;
+  src: string;
+  status: PlayerStatus;
+  error: string | null;
+  reconnectCount: number;
+  setPlaying: (playing: boolean) => void;
   setVolume: (volume: number) => void;
-  setQuality: (quality: StreamQuality) => void;
+  setMuted: (muted: boolean) => void;
+  setStatus: (status: PlayerStatus) => void;
+  setError: (error: string | null) => void;
+  setSrc: (src: string) => void;
+  setReconnectCount: (count: number) => void;
+  resetReconnect: () => void;
 }
 
+const STREAM_SRC = import.meta.env.VITE_STREAM_URL_HLS ?? '';
+
 export const usePlayerStore = create<PlayerState>((set) => ({
-  isPlaying: false,
+  playing: false,
   volume: 1,
-  quality: '128kbps',
-  setPlaying: (isPlaying) => set({ isPlaying }),
+  muted: false,
+  src: STREAM_SRC,
+  status: 'idle',
+  error: null,
+  reconnectCount: 0,
+  setPlaying: (playing) => set({ playing }),
   setVolume: (volume) => set({ volume }),
-  setQuality: (quality) => set({ quality })
+  setMuted: (muted) => set({ muted }),
+  setStatus: (status) => set({ status }),
+  setError: (error) => set({ error }),
+  setSrc: (src) => set({ src }),
+  setReconnectCount: (count) => set({ reconnectCount: count }),
+  resetReconnect: () => set({ reconnectCount: 0 })
 }));


### PR DESCRIPTION
## Summary
- add a hero section player with HLS playback, reconnect handling, and audio visualizer
- introduce shared player store, metadata polling, and localization strings for live playback
- integrate HeroPlayer into the home page with mock now-playing data for development

## Testing
- pnpm lint *(fails: corepack cannot download pnpm in sandbox)*
- pnpm test *(fails: corepack cannot download pnpm in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68db0ee8e6988322a6467f00947e6215