### PR TITLE
feat: add Whisper archival audio section

### DIFF
--- a/src/assets/audio/whisper-2017.mp3
+++ b/src/assets/audio/whisper-2017.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:930c6f08aec64ac45c0b0f7280447db9fce5a6513433403a7de301acf5711d05
+size 38

--- a/src/features/whisper/WhisperCurtain.tsx
+++ b/src/features/whisper/WhisperCurtain.tsx
@@ -1,0 +1,20 @@
+import { memo } from 'react';
+
+import './whisper.css';
+
+interface WhisperCurtainProps {
+  reducedMotion: boolean;
+}
+
+export const WhisperCurtain = memo(function WhisperCurtain({ reducedMotion }: WhisperCurtainProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className="whisper-curtain"
+      data-reduced-motion={reducedMotion ? 'true' : 'false'}
+    >
+      <div className="whisper-panel" />
+      <div className="whisper-panel whisper-panel--right" />
+    </div>
+  );
+});

--- a/src/features/whisper/WhisperSection.test.tsx
+++ b/src/features/whisper/WhisperSection.test.tsx
@@ -1,0 +1,110 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import i18n from '../../i18n';
+import { WhisperSection } from './WhisperSection';
+
+describe('WhisperSection', () => {
+  let reduceMotion = false;
+  const originalMatchMedia = window.matchMedia;
+  const originalPlay = HTMLMediaElement.prototype.play;
+  const originalPause = HTMLMediaElement.prototype.pause;
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query.includes('prefers-reduced-motion') ? reduceMotion : false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        onchange: null,
+        dispatchEvent: vi.fn()
+      })
+    });
+  });
+
+  beforeEach(() => {
+    reduceMotion = false;
+    sessionStorage.clear();
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue();
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    window.matchMedia = originalMatchMedia;
+    HTMLMediaElement.prototype.play = originalPlay;
+    HTMLMediaElement.prototype.pause = originalPause;
+  });
+
+  const renderSection = () =>
+    render(
+      <I18nextProvider i18n={i18n}>
+        <WhisperSection />
+      </I18nextProvider>
+    );
+
+  it('renders the archival audio region and ethics guidance', () => {
+    renderSection();
+
+    expect(screen.getByRole('region', { name: /Szept zza Kurtyny/ })).toBeInTheDocument();
+    expect(screen.getByText('Nagranie dokumentuje napięte przesłuchanie publiczne z 2017 roku.')).toBeInTheDocument();
+  });
+
+  it('starts playback when the play button is pressed', async () => {
+    renderSection();
+    const playButton = screen.getByRole('button', { name: 'Odtwórz' });
+
+    await act(async () => {
+      fireEvent.click(playButton);
+    });
+
+    expect(HTMLMediaElement.prototype.play).toHaveBeenCalled();
+
+    const audioElement = document.querySelector('audio');
+    expect(audioElement).not.toBeNull();
+    audioElement?.dispatchEvent(new Event('play'));
+
+    expect(screen.getByRole('button', { name: 'Wstrzymaj' })).toBeInTheDocument();
+  });
+
+  it('updates aria attributes when volume changes', () => {
+    renderSection();
+    const volumeSlider = screen.getByLabelText('Głośność');
+
+    fireEvent.change(volumeSlider, { target: { value: '0.4' } });
+
+    expect(volumeSlider).toHaveAttribute('aria-valuenow', '0.4');
+    expect(volumeSlider).toHaveAttribute('aria-valuetext', '40%');
+  });
+
+  it('returns to play state after the audio ends', () => {
+    renderSection();
+    const audioElement = document.querySelector('audio');
+    const playButton = screen.getByRole('button', { name: 'Odtwórz' });
+
+    act(() => {
+      playButton.click();
+    });
+
+    audioElement?.dispatchEvent(new Event('play'));
+    audioElement?.dispatchEvent(new Event('ended'));
+
+    expect(screen.getByRole('button', { name: 'Odtwórz' })).toBeInTheDocument();
+  });
+
+  it('disables curtain animation when reduced motion is preferred', () => {
+    reduceMotion = true;
+    const { container } = renderSection();
+    const curtain = container.querySelector('.whisper-curtain');
+    expect(curtain).not.toBeNull();
+    expect(curtain).toHaveAttribute('data-reduced-motion', 'true');
+  });
+});

--- a/src/features/whisper/WhisperSection.tsx
+++ b/src/features/whisper/WhisperSection.tsx
@@ -1,0 +1,350 @@
+import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import whisperAudio from '../../assets/audio/whisper-2017.mp3';
+import { WhisperCurtain } from './WhisperCurtain';
+import './whisper.css';
+
+const FALLBACK_DURATION = 12 * 60 + 34; // 12 minutes 34 seconds
+const STORAGE_KEY = 'whisper-playback-position';
+
+const formatTime = (value: number): string => {
+  const safeValue = Number.isFinite(value) && value >= 0 ? Math.floor(value) : 0;
+  const minutes = Math.floor(safeValue / 60)
+    .toString()
+    .padStart(2, '0');
+  const seconds = Math.floor(safeValue % 60)
+    .toString()
+    .padStart(2, '0');
+
+  return `${minutes}:${seconds}`;
+};
+
+const usePrefersReducedMotion = (): boolean => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const updatePreference = () => {
+      setPrefersReducedMotion(query.matches);
+    };
+
+    updatePreference();
+    query.addEventListener('change', updatePreference);
+
+    return () => {
+      query.removeEventListener('change', updatePreference);
+    };
+  }, []);
+
+  return prefersReducedMotion;
+};
+
+export function WhisperSection(): JSX.Element {
+  const { t } = useTranslation();
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isMuted, setIsMuted] = useState(false);
+  const [volume, setVolume] = useState(1);
+  const [duration, setDuration] = useState(FALLBACK_DURATION);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [statusMessage, setStatusMessage] = useState('');
+
+  const audioSource = useMemo(() => {
+    const envSource = import.meta.env.VITE_WHISPER_AUDIO_URL;
+    return envSource && envSource.length > 0 ? envSource : whisperAudio;
+  }, []);
+
+  const ethicsItems = useMemo(
+    () => t('whisper.ethics.body', { returnObjects: true }) as string[],
+    [t]
+  );
+
+  useEffect(() => {
+    setStatusMessage(t('whisper.status.paused'));
+  }, [t]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    const handleLoadedMetadata = () => {
+      const loadedDuration = Number.isFinite(audio.duration) ? audio.duration : FALLBACK_DURATION;
+      setDuration(loadedDuration);
+
+      if (typeof window !== 'undefined') {
+        const saved = window.sessionStorage.getItem(STORAGE_KEY);
+        if (saved) {
+          const savedPosition = Number.parseFloat(saved);
+          if (Number.isFinite(savedPosition) && savedPosition < loadedDuration && savedPosition >= 0) {
+            audio.currentTime = savedPosition;
+            setCurrentTime(savedPosition);
+          }
+        }
+      }
+    };
+
+    const handleTimeUpdate = () => {
+      const time = audio.currentTime;
+      setCurrentTime(time);
+      if (typeof window !== 'undefined') {
+        window.sessionStorage.setItem(STORAGE_KEY, time.toString());
+      }
+    };
+
+    const handlePlay = () => {
+      setIsPlaying(true);
+      setStatusMessage(t('whisper.status.playing'));
+    };
+
+    const handlePause = () => {
+      setIsPlaying(false);
+      if (!audio.ended) {
+        setStatusMessage(t('whisper.status.paused'));
+      }
+    };
+
+    const handleEnded = () => {
+      setIsPlaying(false);
+      setCurrentTime(0);
+      setStatusMessage(t('whisper.status.ended'));
+      if (typeof window !== 'undefined') {
+        window.sessionStorage.removeItem(STORAGE_KEY);
+      }
+    };
+
+    audio.addEventListener('loadedmetadata', handleLoadedMetadata);
+    audio.addEventListener('timeupdate', handleTimeUpdate);
+    audio.addEventListener('play', handlePlay);
+    audio.addEventListener('pause', handlePause);
+    audio.addEventListener('ended', handleEnded);
+
+    return () => {
+      audio.removeEventListener('loadedmetadata', handleLoadedMetadata);
+      audio.removeEventListener('timeupdate', handleTimeUpdate);
+      audio.removeEventListener('play', handlePlay);
+      audio.removeEventListener('pause', handlePause);
+      audio.removeEventListener('ended', handleEnded);
+    };
+  }, [t]);
+
+  const handlePlayPause = useCallback(async () => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    if (isPlaying) {
+      audio.pause();
+      return;
+    }
+
+    try {
+      await audio.play();
+      setStatusMessage(t('whisper.status.playing'));
+    } catch (error) {
+      // Playback may be blocked by the browser until user interaction.
+      setStatusMessage(t('whisper.status.error'));
+      // eslint-disable-next-line no-console
+      console.error('Unable to play the audio file.', error);
+    }
+  }, [isPlaying, t]);
+
+  const handleRestart = useCallback(async () => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    audio.currentTime = 0;
+    setCurrentTime(0);
+    setStatusMessage(t('whisper.status.restarted'));
+
+    if (isPlaying) {
+      try {
+        await audio.play();
+      } catch (error) {
+        setStatusMessage(t('whisper.status.error'));
+        // eslint-disable-next-line no-console
+        console.error('Unable to resume playback.', error);
+      }
+    }
+  }, [isPlaying, t]);
+
+  const handleSeek = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const audio = audioRef.current;
+      if (!audio) {
+        return;
+      }
+
+      const value = Number.parseFloat(event.target.value);
+      if (!Number.isFinite(value)) {
+        return;
+      }
+
+      audio.currentTime = value;
+      setCurrentTime(value);
+      setStatusMessage(t('whisper.status.seeked'));
+    },
+    [t]
+  );
+
+  const handleVolumeChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const audio = audioRef.current;
+      if (!audio) {
+        return;
+      }
+
+      const value = Number.parseFloat(event.target.value);
+      if (!Number.isFinite(value)) {
+        return;
+      }
+
+      audio.volume = value;
+      setVolume(value);
+      const muted = value === 0;
+      audio.muted = muted;
+      setIsMuted(muted);
+      setStatusMessage(muted ? t('whisper.status.muted') : t('whisper.status.volume'));
+    },
+    [t]
+  );
+
+  const handleMuteToggle = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    const nextMuted = !isMuted;
+    audio.muted = nextMuted;
+    setIsMuted(nextMuted);
+    if (!nextMuted && audio.volume === 0) {
+      audio.volume = 0.5;
+      setVolume(0.5);
+    }
+    setStatusMessage(nextMuted ? t('whisper.status.muted') : t('whisper.status.unmuted'));
+  }, [isMuted, t]);
+
+  return (
+    <section
+      aria-label={t('whisper.regionLabel')}
+      className="whisper-section relative isolate overflow-hidden rounded-3xl border border-white/10 p-6 text-base-50 shadow-xl ring-1 ring-base-800/60 sm:p-10"
+      role="region"
+    >
+      <WhisperCurtain reducedMotion={prefersReducedMotion} />
+      <div className="relative z-10 flex flex-col gap-10 lg:flex-row lg:items-start">
+        <div className="max-w-xl space-y-4">
+          <div className="space-y-2">
+            <p className="text-sm uppercase tracking-[0.3em] text-accent-400">{t('whisper.length')}</p>
+            <h2 className="font-display text-3xl font-semibold text-base-50 sm:text-4xl">{t('whisper.title')}</h2>
+            <p className="text-base text-base-100 sm:text-lg">{t('whisper.subtitle')}</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+            <h3 className="font-medium text-accent-300">{t('whisper.ethics.title')}</h3>
+            <ul className="mt-3 space-y-2 text-sm text-base-100">
+              {ethicsItems.map((item, index) => (
+                <li key={index} className="flex items-start gap-3">
+                  <span aria-hidden="true" className="mt-1 inline-flex h-2 w-2 rounded-full bg-accent-500" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+        <div className="w-full max-w-md space-y-4 rounded-2xl border border-white/10 bg-base-900/70 p-5 backdrop-blur">
+          <div className="flex items-center gap-3">
+            <button
+              className="inline-flex items-center justify-center rounded-full bg-accent-500 px-5 py-2 text-sm font-semibold text-base-50 shadow-lg shadow-accent-500/30 transition hover:bg-accent-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+              onClick={handlePlayPause}
+              type="button"
+            >
+              {isPlaying ? t('whisper.pause') : t('whisper.play')}
+            </button>
+            <button
+              className="inline-flex items-center justify-center rounded-full border border-white/20 px-4 py-2 text-sm font-medium text-base-100 transition hover:border-accent-500/80 hover:text-base-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+              onClick={handleRestart}
+              type="button"
+            >
+              {t('whisper.restart')}
+            </button>
+            <button
+              aria-pressed={isMuted}
+              className="ml-auto inline-flex items-center justify-center rounded-full border border-white/20 p-2 text-sm font-medium text-base-100 transition hover:border-accent-500/80 hover:text-base-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-500"
+              onClick={handleMuteToggle}
+              type="button"
+            >
+              {isMuted ? t('whisper.unmute') : t('whisper.mute')}
+            </button>
+          </div>
+          <div className="space-y-3">
+            <label className="block text-xs uppercase tracking-wide text-base-200" htmlFor="whisper-progress">
+              {t('whisper.scrub')}
+            </label>
+            <input
+              aria-label={t('whisper.scrub')}
+              aria-valuemax={Math.round(duration)}
+              aria-valuemin={0}
+              aria-valuenow={Math.round(currentTime)}
+              aria-valuetext={formatTime(currentTime)}
+              className="h-2 w-full cursor-pointer appearance-none rounded-full bg-base-800 accent-accent-500"
+              id="whisper-progress"
+              max={duration}
+              min={0}
+              onChange={handleSeek}
+              step={1}
+              type="range"
+              value={currentTime}
+            />
+            <div className="flex justify-between text-xs text-base-200">
+              <span>{formatTime(currentTime)}</span>
+              <span>{formatTime(duration)}</span>
+            </div>
+          </div>
+          <div className="space-y-3">
+            <label className="block text-xs uppercase tracking-wide text-base-200" htmlFor="whisper-volume">
+              {t('whisper.volume')}
+            </label>
+            <input
+              aria-label={t('whisper.volume')}
+              aria-valuemax={1}
+              aria-valuemin={0}
+              aria-valuenow={Number(volume.toFixed(2))}
+              aria-valuetext={`${Math.round(volume * 100)}%`}
+              className="h-2 w-full cursor-pointer appearance-none rounded-full bg-base-800 accent-accent-500"
+              id="whisper-volume"
+              max={1}
+              min={0}
+              onChange={handleVolumeChange}
+              step={0.01}
+              type="range"
+              value={volume}
+            />
+            <div className="flex justify-between text-xs text-base-200">
+              <span>0%</span>
+              <span>100%</span>
+            </div>
+          </div>
+          <div aria-live="polite" className="text-xs text-base-200">
+            {statusMessage}
+          </div>
+          <audio
+            aria-hidden="true"
+            preload="metadata"
+            ref={audioRef}
+            src={audioSource}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/whisper/whisper.css
+++ b/src/features/whisper/whisper.css
@@ -1,0 +1,88 @@
+.whisper-section {
+  position: relative;
+  overflow: hidden;
+  background: radial-gradient(circle at 20% 20%, rgba(26, 31, 58, 0.55), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(15, 19, 40, 0.55), transparent 50%),
+    linear-gradient(135deg, #0a0e27, #151b38 50%, #1a1f3a);
+}
+
+.whisper-curtain {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.whisper-curtain::after {
+  content: '';
+  position: absolute;
+  inset: -200%;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.08'/%3E%3C/svg%3E");
+  mix-blend-mode: screen;
+  animation: whisper-grain 18s steps(10) infinite;
+}
+
+.whisper-panel {
+  position: absolute;
+  top: -10%;
+  bottom: -10%;
+  left: -10%;
+  width: 55%;
+  background: radial-gradient(circle at 0% 50%, rgba(10, 14, 39, 0.9), rgba(10, 14, 39, 0.35) 60%, transparent);
+  box-shadow: inset -30px 0 80px rgba(4, 7, 19, 0.6);
+  animation: whisper-sway-left 14s ease-in-out infinite alternate;
+}
+
+.whisper-panel--right {
+  left: auto;
+  right: -10%;
+  transform: scaleX(-1);
+  box-shadow: inset 30px 0 80px rgba(4, 7, 19, 0.65);
+  animation-name: whisper-sway-right;
+  animation-delay: 1.8s;
+}
+
+@keyframes whisper-sway-left {
+  0% {
+    transform: translateX(-8px) skewY(-1deg);
+  }
+  50% {
+    transform: translateX(4px) skewY(0deg);
+  }
+  100% {
+    transform: translateX(-12px) skewY(1deg);
+  }
+}
+
+@keyframes whisper-sway-right {
+  0% {
+    transform: scaleX(-1) translateX(-12px) skewY(1deg);
+  }
+  50% {
+    transform: scaleX(-1) translateX(6px) skewY(0deg);
+  }
+  100% {
+    transform: scaleX(-1) translateX(-8px) skewY(-1deg);
+  }
+}
+
+@keyframes whisper-grain {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  100% {
+    transform: translate3d(5%, 5%, 0);
+  }
+}
+
+[data-reduced-motion='true'] .whisper-panel,
+[data-reduced-motion='true'] .whisper-curtain::after {
+  animation: none !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .whisper-panel,
+  .whisper-curtain::after {
+    animation: none !important;
+  }
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -40,5 +40,37 @@
       "dark": "Dark mode"
     },
     "language": "Language"
+  },
+  "whisper": {
+    "title": "Whisper Behind the Curtain",
+    "subtitle": "Amid accusations and manipulation, sometimes a single quiet voice can restore perspective.",
+    "length": "2017 · 12:34",
+    "play": "Play",
+    "pause": "Pause",
+    "restart": "Restart",
+    "mute": "Mute",
+    "unmute": "Unmute",
+    "volume": "Volume",
+    "scrub": "Seek position",
+    "regionLabel": "Whisper Behind the Curtain – archival recording",
+    "ethics": {
+      "title": "Listening ethics",
+      "body": [
+        "This archival document captures a tense public hearing from 2017.",
+        "Approach the voices with empathy; they reflect lived experiences.",
+        "Please refrain from sharing excerpts outside educational contexts."
+      ]
+    },
+    "status": {
+      "playing": "Playback started.",
+      "paused": "Playback paused.",
+      "ended": "Playback ended.",
+      "restarted": "Playback restarted from the beginning.",
+      "seeked": "Position updated.",
+      "muted": "Audio muted.",
+      "unmuted": "Audio unmuted.",
+      "volume": "Volume adjusted.",
+      "error": "Playback could not start."
+    }
   }
 }

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -40,5 +40,37 @@
       "dark": "Donkere modus"
     },
     "language": "Taal"
+  },
+  "whisper": {
+    "title": "Fluister achter het Gordijn",
+    "subtitle": "Temidden van beschuldigingen en manipulatie kan één stille stem het perspectief terugbrengen.",
+    "length": "2017 · 12:34",
+    "play": "Afspelen",
+    "pause": "Pauze",
+    "restart": "Opnieuw starten",
+    "mute": "Dempen",
+    "unmute": "Geluid aan",
+    "volume": "Volume",
+    "scrub": "Zoek positie",
+    "regionLabel": "Fluister achter het Gordijn – archiefopname",
+    "ethics": {
+      "title": "Luisterethiek",
+      "body": [
+        "Deze archiefopname legt een gespannen openbare hoorzitting uit 2017 vast.",
+        "Luister met empathie; de stemmen getuigen van geleefde ervaringen.",
+        "Deel geen fragmenten buiten een educatieve context."
+      ]
+    },
+    "status": {
+      "playing": "Afspelen gestart.",
+      "paused": "Afspelen gepauzeerd.",
+      "ended": "Afspelen beëindigd.",
+      "restarted": "Opnieuw vanaf het begin.",
+      "seeked": "Positie bijgewerkt.",
+      "muted": "Audio gedempt.",
+      "unmuted": "Audio hoorbaar.",
+      "volume": "Volume aangepast.",
+      "error": "Afspelen kon niet starten."
+    }
   }
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -40,5 +40,37 @@
       "dark": "Tryb ciemny"
     },
     "language": "Język"
+  },
+  "whisper": {
+    "title": "Szept zza Kurtyny",
+    "subtitle": "W czasie oskarżeń i manipulacji, czasem jeden, cichy głos może przywrócić perspektywę.",
+    "length": "2017 · 12:34",
+    "play": "Odtwórz",
+    "pause": "Wstrzymaj",
+    "restart": "Zacznij od nowa",
+    "mute": "Wycisz",
+    "unmute": "Przywróć dźwięk",
+    "volume": "Głośność",
+    "scrub": "Przewiń nagranie",
+    "regionLabel": "Szept zza Kurtyny – nagranie archiwalne",
+    "ethics": {
+      "title": "Etyka odsłuchu",
+      "body": [
+        "Nagranie dokumentuje napięte przesłuchanie publiczne z 2017 roku.",
+        "Słuchaj z empatią – to czyjeś prawdziwe doświadczenia.",
+        "Nie udostępniaj fragmentów poza kontekstem edukacyjnym."
+      ]
+    },
+    "status": {
+      "playing": "Rozpoczęto odtwarzanie.",
+      "paused": "Odtwarzanie wstrzymane.",
+      "ended": "Nagranie zakończone.",
+      "restarted": "Odtwarzanie od początku.",
+      "seeked": "Pozycja nagrania zmieniona.",
+      "muted": "Dźwięk wyciszony.",
+      "unmuted": "Dźwięk przywrócony.",
+      "volume": "Głośność zaktualizowana.",
+      "error": "Nie udało się uruchomić odtwarzania."
+    }
   }
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,12 +1,17 @@
 import { useTranslation } from 'react-i18next';
 
+import { WhisperSection } from '../features/whisper/WhisperSection';
+
 export default function Home(): JSX.Element {
   const { t } = useTranslation();
 
   return (
-    <section className="space-y-4">
-      <h1 className="text-3xl font-bold text-base-50 sm:text-4xl">{t('pages.home.title')}</h1>
-      <p className="max-w-2xl text-base-200">{t('pages.home.lead')}</p>
-    </section>
+    <div className="space-y-12">
+      <section className="space-y-4">
+        <h1 className="text-3xl font-bold text-base-50 sm:text-4xl">{t('pages.home.title')}</h1>
+        <p className="max-w-2xl text-base-200">{t('pages.home.lead')}</p>
+      </section>
+      <WhisperSection />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add the Whisper section with an accessible archival audio player, animated curtain backdrop, and listening ethics block
- localize the new copy in Polish, Dutch, and English and mount the section on the home page
- cover playback, volume, completion, and reduced motion behaviour with unit tests

## Testing
- pnpm lint *(fails: unable to download pnpm due to offline environment)*
- node_modules/.bin/eslint . --max-warnings=0 *(fails: missing @eslint/js dependency in offline environment)*
- node_modules/.bin/vitest run *(fails: missing @vitejs/plugin-react dependency in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db0f6cdce48322b0a6dcf96ffd755a