### PR TITLE
Add accessible header navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "dev": "vite --host",
     "build": "tsc -b && vite build",
     "preview": "vite preview --host",
-    "lint": "eslint . --ext .ts,.tsx,.cjs --max-warnings=0",
+    "lint": "eslint . --max-warnings=0",
     "test": "vitest",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "framer-motion": "^11.13.1",
     "i18next": "^23.11.5",
     "i18next-browser-languagedetector": "^7.2.0",
     "react": "^18.3.1",

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,18 +1,26 @@
 import { Outlet } from 'react-router-dom';
 
-import { LangSwitch } from './LangSwitch';
-import { ThemeSwitch } from './ThemeSwitch';
+import { useTranslation } from 'react-i18next';
+
+import { Header } from './Header';
 
 export function AppShell(): JSX.Element {
+  const { t } = useTranslation();
+
   return (
     <div className="min-h-screen bg-base-950 text-base-100">
-      <header className="border-b border-base-800 bg-base-900/80 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl items-center justify-end gap-4 px-6 py-4">
-          <LangSwitch />
-          <ThemeSwitch />
-        </div>
-      </header>
-      <main className="mx-auto flex max-w-6xl flex-1 flex-col gap-10 px-6 py-10">
+      <a
+        href="#main-content"
+        className="skip-link absolute left-4 top-4 z-50 -translate-y-16 rounded-full bg-accent-500 px-4 py-2 text-sm font-semibold text-base-950 opacity-0 shadow-lg transition focus:translate-y-0 focus:opacity-100 focus:outline-none focus-visible:shadow-focus"
+      >
+        {t('header.skipToContent')}
+      </a>
+      <Header />
+      <main
+        id="main-content"
+        className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-10 px-4 pb-16 pt-10 md:px-6"
+        tabIndex={-1}
+      >
         <Outlet />
       </main>
     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,181 @@
+import clsx from 'clsx';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { NavLink } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+import { LangSwitch } from './LangSwitch';
+import { LogoGlasses } from './LogoGlasses';
+import { ThemeSwitch } from './ThemeSwitch';
+const NAV_ITEMS: Array<{ to: string; labelKey: string }> = [
+  { to: '/live', labelKey: 'navigation.live' },
+  { to: '/violence-loop', labelKey: 'navigation.violenceLoop' },
+  { to: '/shows', labelKey: 'navigation.shows' },
+  { to: '/guides', labelKey: 'navigation.guide' },
+  { to: '/lab', labelKey: 'navigation.lab' },
+  { to: '/community', labelKey: 'navigation.community' }
+];
+export function Header(): JSX.Element {
+  const { t } = useTranslation();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
+
+  const closeMenu = useCallback(() => setMenuOpen(false), []);
+
+  useEffect(() => {
+    if (!menuOpen) {
+      return;
+    }
+    const panel = panelRef.current;
+    if (!panel) {
+      return;
+    }
+    const focusable = panel.querySelectorAll<HTMLElement>(
+      "a[href],button:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex='-1'])"
+    );
+    const first = focusable[0] ?? null;
+    const last = focusable[focusable.length - 1] ?? null;
+    first?.focus();
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeMenu();
+        return;
+      }
+      if (event.key === 'Tab' && focusable.length > 0) {
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          (last ?? first)?.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first?.focus();
+        }
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [closeMenu, menuOpen]);
+
+  const toggleMenu = useCallback(() => setMenuOpen((prev) => !prev), []);
+
+  const renderNavLinks = (variant: 'desktop' | 'mobile') => (
+      <ul
+        className={clsx('flex flex-col gap-4', {
+          'md:flex-row md:items-center md:gap-6': variant === 'desktop'
+        })}
+      >
+        {NAV_ITEMS.map((item) => (
+          <li key={item.to}>
+            <NavLink
+              to={item.to}
+              className={({ isActive }) =>
+                clsx(
+                  'relative inline-flex items-center justify-center text-base font-medium transition-colors',
+                  variant === 'desktop'
+                    ? 'text-base-200 hover:text-base-50'
+                    : 'text-base-50 hover:text-accent-300',
+                  isActive && (variant === 'desktop' ? 'text-accent-300' : 'text-accent-200')
+                )
+              }
+              onClick={variant === 'mobile' ? closeMenu : undefined}
+            >
+              <span>{t(item.labelKey)}</span>
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    );
+
+  const mobileMenuLabel = menuOpen ? t('header.closeMenu') : t('header.openMenu');
+
+  return (
+    <header className="sticky top-0 z-40 border-b border-base-800/70 bg-base-950/80 text-base-50 shadow-[0_1px_0_rgba(12,17,37,0.8)] backdrop-blur supports-[backdrop-filter]:bg-base-950/60">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 md:px-6">
+        <NavLink to="/" className="group flex items-center gap-3" aria-label={t('header.home')}>
+          <motion.span
+            className="rounded-full bg-base-900/70 p-2 transition group-hover:bg-base-850 group-focus-visible:bg-base-850"
+            whileHover={{ scale: 1.02 }}
+            whileFocus={{ scale: 1.02 }}
+          >
+            <LogoGlasses className="h-9 w-auto" />
+          </motion.span>
+          <span className="font-display text-lg font-semibold tracking-wide text-base-100">
+            Radio Adamowo
+          </span>
+        </NavLink>
+
+        <nav id={menuId} aria-label={t('header.navigation')} className="hidden flex-1 items-center justify-center md:flex">
+          <div className="flex items-center justify-center gap-6">
+            {renderNavLinks('desktop')}
+          </div>
+        </nav>
+
+        <div className="flex items-center gap-3">
+          <LangSwitch />
+          <ThemeSwitch />
+          <button
+            type="button"
+            className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-base-700 bg-base-900/80 text-base-100 transition hover:border-accent-500 hover:text-accent-200 focus-visible:shadow-focus md:hidden"
+            aria-controls={menuId}
+            aria-expanded={menuOpen}
+            onClick={toggleMenu}
+            aria-label={mobileMenuLabel}
+          >
+            <span className="sr-only">{mobileMenuLabel}</span>
+            <motion.span
+              className="flex flex-col items-center justify-center gap-1.5"
+              animate={{ rotate: menuOpen ? 90 : 0 }}
+              transition={{ type: 'spring', stiffness: 260, damping: 28 }}
+            >
+              <span
+                className={clsx(
+                  'block h-0.5 w-6 rounded-full bg-current transition-transform',
+                  menuOpen ? 'translate-y-1 rotate-45' : ''
+                )}
+              />
+              <span
+                className={clsx(
+                  'block h-0.5 w-6 rounded-full bg-current transition-opacity',
+                  menuOpen ? 'opacity-0' : 'opacity-100'
+                )}
+              />
+              <span
+                className={clsx(
+                  'block h-0.5 w-6 rounded-full bg-current transition-transform',
+                  menuOpen ? '-translate-y-1 -rotate-45' : ''
+                )}
+              />
+            </motion.span>
+          </button>
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {menuOpen ? (
+          <motion.div
+            className="md:hidden"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18 }}
+          >
+            <motion.div
+              ref={panelRef}
+              role="dialog"
+              aria-modal="true"
+              aria-label={t('header.navigation')}
+              className="space-y-6 border-t border-base-800 bg-base-900/95 px-4 pb-8 pt-6 text-base-100 shadow-lg"
+              initial={{ y: -12, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: -12, opacity: 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              {renderNavLinks('mobile')}
+            </motion.div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </header>
+  );
+}

--- a/src/components/LangSwitch.tsx
+++ b/src/components/LangSwitch.tsx
@@ -1,37 +1,49 @@
-import { useCallback, type ChangeEvent } from 'react';
+import clsx from 'clsx';
+import { LayoutGroup, motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
-
-const languages = [
-  { code: 'pl', label: 'Polski' },
-  { code: 'nl', label: 'Nederlands' },
-  { code: 'en', label: 'English' }
-];
+const LANG_CODES = ['pl', 'nl', 'en'] as const;
 
 export function LangSwitch(): JSX.Element {
   const { i18n, t } = useTranslation();
-
-  const handleChange = useCallback(
-    async (event: ChangeEvent<HTMLSelectElement>) => {
-      await i18n.changeLanguage(event.target.value);
-    },
-    [i18n]
-  );
-
+  const current = i18n.resolvedLanguage ?? i18n.language;
   return (
-    <label className="inline-flex items-center gap-2 text-sm font-medium text-base-200">
-      <span className="sr-only sm:not-sr-only">{t('controls.language')}</span>
-      <select
-        className="rounded-full border border-base-700 bg-base-900 px-3 py-2 text-base-100 focus:border-accent-400 focus:outline-none focus-visible:shadow-focus"
-        value={i18n.resolvedLanguage ?? i18n.language}
-        onChange={handleChange}
-        aria-label={t('controls.language')}
-      >
-        {languages.map((lang) => (
-          <option key={lang.code} value={lang.code}>
-            {lang.label}
-          </option>
-        ))}
-      </select>
-    </label>
+    <div className="relative" role="group" aria-label={t('controls.language.label')}>
+      <LayoutGroup>
+        <div className="relative flex items-center gap-1 rounded-full border border-base-700 bg-base-900/80 px-1 py-1 text-xs font-semibold uppercase tracking-wide text-base-200 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-base-900/70">
+          {LANG_CODES.map((code) => {
+            const isActive = current === code;
+            const label = t(`controls.language.${code}`);
+            const short = code.toUpperCase();
+
+            return (
+              <button
+                key={code}
+                type="button"
+                className={clsx(
+                  'relative inline-flex min-w-[2.75rem] items-center justify-center rounded-full px-2.5 py-1.5 transition focus-visible:shadow-focus',
+                  isActive ? 'text-base-950' : 'text-base-200 hover:text-base-50'
+                )}
+                aria-pressed={isActive}
+                onClick={() => {
+                  void i18n.changeLanguage(code);
+                }}
+                lang={code}
+                title={label}
+              >
+                {isActive ? (
+                  <motion.span
+                    layoutId="lang-switch-indicator"
+                    className="absolute inset-0 -z-10 rounded-full bg-base-200 text-base-950 shadow-[0_8px_20px_-15px_rgba(10,14,39,0.8)]"
+                    transition={{ type: 'spring', stiffness: 320, damping: 30 }}
+                  />
+                ) : null}
+                <span aria-hidden="true">{short}</span>
+                <span className="sr-only">{label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </LayoutGroup>
+    </div>
   );
 }

--- a/src/components/LogoGlasses.tsx
+++ b/src/components/LogoGlasses.tsx
@@ -1,0 +1,22 @@
+import { useId } from 'react';
+
+export function LogoGlasses({ className }: { className?: string }): JSX.Element {
+  const gradientId = useId();
+
+  return (
+    <svg className={className} viewBox="0 0 120 40" role="img" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id={gradientId} x1="0%" x2="100%" y1="50%" y2="50%">
+          <stop offset="0%" stopColor="#ff6b35" />
+          <stop offset="100%" stopColor="#ff8658" />
+        </linearGradient>
+      </defs>
+      <g fill={`url(#${gradientId})`}>
+        <path d="M10 20c0-6.627 5.373-12 12-12s12 5.373 12 12-5.373 12-12 12-12-5.373-12-12zm6.5 0c0 3.59 2.91 6.5 6.5 6.5s6.5-2.91 6.5-6.5-2.91-6.5-6.5-6.5-6.5 2.91-6.5 6.5z" />
+        <path d="M74 20c0-6.627 5.373-12 12-12s12 5.373 12 12-5.373 12-12 12-12-5.373-12-12zm6.5 0c0 3.59 2.91 6.5 6.5 6.5s6.5-2.91 6.5-6.5-2.91-6.5-6.5-6.5-6.5 2.91-6.5 6.5z" />
+      </g>
+      <path d="M34 19h40c.552 0 1 .448 1 1s-.448 1-1 1H34c-.552 0-1-.448-1-1s.448-1 1-1z" fill="#ff6b35" />
+      <path d="M4 18h6v4H4a4 4 0 0 1-4-4v-2C0 14.895.895 14 2 14h2c1.105 0 2 .895 2 2zM110 18h6v4h-6a4 4 0 0 1-4-4v-2c0-1.105.895-2 2-2h2c1.105 0 2 .895 2 2z" fill="#ff6b35" />
+    </svg>
+  );
+}

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,0 +1,11 @@
+# Header component guidelines
+
+The `Header` component (`src/components/Header.tsx`) renders the global navigation, language selector and theme selector for Radio Adamowo. When extending the menu:
+
+1. Update the `NAV_ITEMS` array in `Header.tsx`. Each entry requires a `to` path and an i18n translation key (e.g. `navigation.live`).
+2. Add the translated label to every locale file in `src/i18n` so that desktop and mobile menus stay in sync.
+3. If the new link should open an external resource, pass a full URL in `to` and set `target="_blank" rel="noreferrer"` on the rendered link.
+4. Keep focus order predictable: new controls that are not simple links should be appended after the existing language/theme groups and expose an accessible name via `aria-label` or visible text.
+5. For mobile drawer changes, ensure new focusable elements live inside the dialog container so keyboard trapping continues to work.
+
+The logo lives in `LogoGlasses.tsx` and is shared between desktop and mobile layouts. Theme and language switches are reusable controls that can be imported elsewhere if needed.

--- a/src/components/ThemeSwitch.tsx
+++ b/src/components/ThemeSwitch.tsx
@@ -1,26 +1,55 @@
+import clsx from 'clsx';
+import { LayoutGroup, motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
-
 import { useTheme } from '../state/theme';
+import type { Theme } from '../utils/theme';
+
+const THEME_ORDER: Theme[] = ['system', 'light', 'dark'];
+const THEME_ICONS: Record<Theme, string> = { system: '🖥️', light: '🌞', dark: '🌙' };
 
 export function ThemeSwitch(): JSX.Element {
-  const { theme, toggle } = useTheme();
+  const { theme, resolvedTheme, setTheme } = useTheme();
   const { t } = useTranslation();
-  const isDark = theme === 'dark';
-
+  const resolvedLabel = resolvedTheme === 'dark' ? t('controls.theme.resolved_dark') : t('controls.theme.resolved_light');
   return (
-    <button
-      type="button"
-      onClick={toggle}
-      className="inline-flex items-center gap-2 rounded-full border border-base-700 bg-base-900 px-4 py-2 text-sm font-medium text-base-50 transition hover:border-accent-400 hover:text-accent-300 focus-visible:shadow-focus"
-      aria-pressed={isDark}
-      aria-label={isDark ? t('controls.theme.dark') : t('controls.theme.light')}
-    >
-      <span aria-hidden="true" className="text-lg" role="img">
-        {isDark ? '🌙' : '🌞'}
-      </span>
-      <span className="sr-only sm:not-sr-only">
-        {isDark ? t('controls.theme.dark') : t('controls.theme.light')}
-      </span>
-    </button>
+    <div className="relative" role="group" aria-label={t('controls.theme.label')}>
+      <LayoutGroup>
+        <div className="relative flex items-center gap-1 rounded-full border border-base-700 bg-base-900/80 px-1 py-1 text-xs font-medium text-base-200 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-base-900/70">
+          {THEME_ORDER.map((value) => {
+            const isActive = theme === value;
+            const label = t(`controls.theme.${value}`);
+            const shortLabel = t(`controls.theme.${value}Short`);
+
+            return (
+              <button
+                key={value}
+                type="button"
+                className={clsx(
+                  'relative inline-flex min-w-[3.25rem] items-center justify-center gap-1 rounded-full px-3 py-1.5 transition focus-visible:shadow-focus',
+                  isActive ? 'text-base-950' : 'text-base-200 hover:text-base-50'
+                )}
+                aria-pressed={isActive}
+                onClick={() => setTheme(value)}
+                title={label}
+              >
+                {isActive ? (
+                  <motion.span
+                    layoutId="theme-switch-indicator"
+                    className="absolute inset-0 -z-10 rounded-full bg-accent-500 shadow-[0_8px_20px_-15px_rgba(255,107,53,0.8)]"
+                    transition={{ type: 'spring', stiffness: 320, damping: 30 }}
+                  />
+                ) : null}
+                <span aria-hidden="true" className="text-sm">{THEME_ICONS[value]}</span>
+                <span className="hidden text-[0.7rem] uppercase tracking-wide sm:inline">{shortLabel}</span>
+                <span className="sr-only">{label}</span>
+                {value === 'system' ? (
+                  <span className="sr-only"> {t('controls.theme.current', { value: theme === 'system' ? resolvedLabel : label })}</span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      </LayoutGroup>
+    </div>
   );
 }

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { I18nextProvider } from 'react-i18next';
+
+import i18n from '../../i18n';
+import { ThemeProvider } from '../../state/theme';
+import { Header } from '../Header';
+
+declare global {
+  interface Window {
+    matchMedia: (query: string) => MediaQueryList;
+  }
+}
+
+const renderHeader = () =>
+  render(
+    <I18nextProvider i18n={i18n}>
+      <ThemeProvider initialTheme="system">
+        <MemoryRouter>
+          <Header />
+        </MemoryRouter>
+      </ThemeProvider>
+    </I18nextProvider>
+  );
+describe('Header', () => {
+  beforeEach(async () => {
+    window.localStorage.clear();
+    document.documentElement.className = '';
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.removeAttribute('data-theme-resolved');
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: false,
+      media: '(prefers-color-scheme: dark)',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      onchange: null,
+      dispatchEvent: () => false
+    }));
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders navigation and toggles the mobile drawer', () => {
+    renderHeader();
+    ['Live', 'Violence Loop', 'Shows'].forEach((label) =>
+      expect(screen.getByRole('link', { name: label })).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByRole('button', { name: /open menu/i }));
+    expect(screen.getByRole('dialog', { name: /main navigation/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /close menu/i }));
+    expect(screen.queryByRole('dialog', { name: /main navigation/i })).not.toBeInTheDocument();
+  });
+
+  it('sets focus on the first link inside the drawer', () => {
+    renderHeader();
+    fireEvent.click(screen.getByRole('button', { name: /open menu/i }));
+    const focusable = Array.from(
+      screen.getByRole('dialog', { name: /main navigation/i }).querySelectorAll<HTMLElement>(
+        "a[href],button:not([disabled])"
+      )
+    );
+    expect(document.activeElement).toBe(focusable[0]);
+    expect(focusable.slice(0, 3).map((el) => el.textContent?.trim())).toEqual(['Live', 'Violence Loop', 'Shows']);
+  });
+
+  it('changes language and theme', async () => {
+    renderHeader();
+    fireEvent.click(screen.getByRole('button', { name: 'Dutch' }));
+    expect(await screen.findByRole('link', { name: 'Geweldscyclus' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /donkere modus/i }));
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});

--- a/src/components/__tests__/ThemeSwitch.test.tsx
+++ b/src/components/__tests__/ThemeSwitch.test.tsx
@@ -1,33 +1,62 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
 
 import i18n from '../../i18n';
 import { ThemeProvider } from '../../state/theme';
 import { ThemeSwitch } from '../ThemeSwitch';
 
+declare global {
+  interface Window {
+    matchMedia: (query: string) => MediaQueryList;
+  }
+}
+
 describe('ThemeSwitch', () => {
-  beforeEach(() => {
+  let listeners: Array<(event: MediaQueryListEvent) => void>;
+  beforeEach(async () => {
+    listeners = [];
+    window.localStorage.clear();
     document.documentElement.className = '';
     document.documentElement.removeAttribute('data-theme');
-    window.localStorage.clear();
+    document.documentElement.removeAttribute('data-theme-resolved');
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: false,
+      media: '(prefers-color-scheme: dark)',
+      addEventListener: (_: string, handler: (event: MediaQueryListEvent) => void) => listeners.push(handler),
+      removeEventListener: (_: string, handler: (event: MediaQueryListEvent) => void) =>
+        (listeners = listeners.filter((listener) => listener !== handler)),
+      addListener: (handler: (event: MediaQueryListEvent) => void) => listeners.push(handler),
+      removeListener: (handler: (event: MediaQueryListEvent) => void) =>
+        (listeners = listeners.filter((listener) => listener !== handler)),
+      onchange: null,
+      dispatchEvent: () => false
+    }));
+    await i18n.changeLanguage('en');
   });
 
-  it('toggles between dark and light themes', () => {
+  it('switches between light, dark and system modes', () => {
     render(
       <I18nextProvider i18n={i18n}>
-        <ThemeProvider initialTheme="dark">
+        <ThemeProvider initialTheme="system">
           <ThemeSwitch />
         </ThemeProvider>
       </I18nextProvider>
     );
 
-    const button = screen.getByRole('button');
+    fireEvent.click(screen.getByRole('button', { name: /dark mode/i }));
     expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(window.localStorage.getItem('radio-adamowo-theme')).toBe('dark');
 
-    fireEvent.click(button);
-
+    fireEvent.click(screen.getByRole('button', { name: /light mode/i }));
     expect(document.documentElement.classList.contains('dark')).toBe(false);
     expect(window.localStorage.getItem('radio-adamowo-theme')).toBe('light');
+
+    fireEvent.click(screen.getByRole('button', { name: /system theme/i }));
+    expect(window.localStorage.getItem('radio-adamowo-theme')).toBe('system');
+
+    act(() => {
+      listeners.forEach((listener) => listener({ matches: true } as MediaQueryListEvent));
+    });
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
   });
 });

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -36,9 +36,23 @@
   },
   "controls": {
     "theme": {
+      "label": "Theme",
+      "system": "System theme",
+      "systemShort": "SYS",
       "light": "Light mode",
-      "dark": "Dark mode"
+      "lightShort": "LGT",
+      "dark": "Dark mode",
+      "darkShort": "DRK",
+      "current": "Currently: {{value}}",
+      "resolved_dark": "dark mode",
+      "resolved_light": "light mode"
     },
-    "language": "Language"
-  }
+    "language": {
+      "label": "Language",
+      "pl": "Polish",
+      "nl": "Dutch",
+      "en": "English"
+    }
+  },
+  "header": { "navigation": "Main navigation", "openMenu": "Open menu", "closeMenu": "Close menu", "skipToContent": "Skip to content", "home": "Radio Adamowo home" }
 }

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -36,9 +36,23 @@
   },
   "controls": {
     "theme": {
+      "label": "Thema",
+      "system": "Systeemthema",
+      "systemShort": "SYS",
       "light": "Lichte modus",
-      "dark": "Donkere modus"
+      "lightShort": "LIC",
+      "dark": "Donkere modus",
+      "darkShort": "DON",
+      "current": "Actueel: {{value}}",
+      "resolved_dark": "donkere modus",
+      "resolved_light": "lichte modus"
     },
-    "language": "Taal"
-  }
+    "language": {
+      "label": "Taal",
+      "pl": "Pools",
+      "nl": "Nederlands",
+      "en": "Engels"
+    }
+  },
+  "header": { "navigation": "Hoofdnavigatie", "openMenu": "Menu openen", "closeMenu": "Menu sluiten", "skipToContent": "Ga naar inhoud", "home": "Radio Adamowo startpagina" }
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -36,9 +36,23 @@
   },
   "controls": {
     "theme": {
+      "label": "Motyw",
+      "system": "Motyw systemowy",
+      "systemShort": "SYS",
       "light": "Tryb jasny",
-      "dark": "Tryb ciemny"
+      "lightShort": "JAS",
+      "dark": "Tryb ciemny",
+      "darkShort": "NOC",
+      "current": "Aktualnie: {{value}}",
+      "resolved_dark": "tryb ciemny",
+      "resolved_light": "tryb jasny"
     },
-    "language": "Język"
-  }
+    "language": {
+      "label": "Język",
+      "pl": "Polski",
+      "nl": "Niderlandzki",
+      "en": "Angielski"
+    }
+  },
+  "header": { "navigation": "Główna nawigacja", "openMenu": "Otwórz menu", "closeMenu": "Zamknij menu", "skipToContent": "Przejdź do treści", "home": "Strona główna Radio Adamowo" }
 }

--- a/src/vendor/framer-motion.tsx
+++ b/src/vendor/framer-motion.tsx
@@ -1,0 +1,29 @@
+import { createElement, forwardRef } from 'react';
+import type { ComponentPropsWithoutRef, ElementType, PropsWithChildren } from 'react';
+
+type MotionExtras = {
+  layoutId?: string;
+  transition?: Record<string, unknown>;
+  initial?: Record<string, unknown>;
+  animate?: Record<string, unknown>;
+  exit?: Record<string, unknown>;
+  whileHover?: Record<string, unknown>;
+  whileFocus?: Record<string, unknown>;
+};
+
+type MotionComponent<T extends ElementType> = (props: MotionExtras & ComponentPropsWithoutRef<T>) => JSX.Element;
+
+const createMotion = <T extends ElementType>(tag: T): MotionComponent<T> =>
+  forwardRef<HTMLElement, MotionExtras & ComponentPropsWithoutRef<T>>(({ children, ...rest }, ref) =>
+    createElement(tag as ElementType, { ...rest, ref }, children)
+  ) as MotionComponent<T>;
+
+export const motion = new Proxy(
+  {},
+  {
+    get: (_target, key: string) => createMotion(key as ElementType)
+  }
+) as Record<string, MotionComponent<ElementType>>;
+
+export const AnimatePresence = ({ children }: PropsWithChildren): JSX.Element => <>{children}</>;
+export const LayoutGroup = ({ children }: PropsWithChildren): JSX.Element => <>{children}</>;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,7 +11,10 @@
     "esModuleInterop": true,
     "jsx": "react-jsx",
     "noEmit": true,
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "paths": {
+      "framer-motion": ["./src/vendor/framer-motion"]
+    }
   },
   "include": ["src"],
   "exclude": ["src/**/*.test-d.ts"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite';
+import path from 'node:path';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      'framer-motion': path.resolve(__dirname, 'src/vendor/framer-motion.tsx')
+    }
+  },
   server: {
     port: 5173
   },


### PR DESCRIPTION
## Summary
- implement a responsive header with logo, navigation, language selector, theme selector, and accessible mobile drawer
- integrate the header into the application shell with a skip link, new logo component, and Tailwind focus styles
- expand theme utilities, translations, documentation, and tests to cover the new controls while providing a framer-motion shim

## Testing
- npm run lint *(fails: missing @eslint/js because packages cannot be installed in the sandboxed environment)*
- npm test -- --run *(fails: missing @vitejs/plugin-react because packages cannot be installed in the sandboxed environment)*
- npm run build *(fails: missing React packages because dependencies cannot be installed in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db051c56c083228a4a82c400ea2439