### PR TITLE
docs: add radio adamowo structure overview

### DIFF
--- a/docs/user/radio-adamowo-structure.md
+++ b/docs/user/radio-adamowo-structure.md
@@ -1,0 +1,99 @@
+# Kompleksowy opis struktury serwisu Radio Adamowo
+
+## Kolorystyka i styl wizualny
+- **Tło:** gradienty w odcieniach ciemnego granatu i czerni (`#0a0e27` → `#1a1f3a`).
+- **Akcenty:** pomarańcz (`#ff6b35`) oraz motyw czerwonych okularów jako wyróżnik marki.
+- **Karty i moduły:** ciemne panele z delikatnymi gradientami, neonowymi krawędziami i subtelną poświatą.
+- **Typografia:** kontrastowe fonty bezszeryfowe; nagłówki w barwie pomarańczowej, teksty akapitów jasnoszare dla czytelności.
+
+## Struktura główna
+### 1. Nagłówek serwisu
+- Logo „Radio Adamowo” z czerwonymi okularami.
+- Nawigacja główna: **Na Żywo | Pętla Przemocy | Audycje | Poradnik | Laboratorium | Społeczność**.
+- Przyciski trybu jasny/ciemny oraz przełącznik języka.
+
+### 2. Sekcja hero – odtwarzacz główny
+- Hasło: „Radio Adamowo: Muzyka z Eteru”.
+- Informacja o transmisji 24/7 bez reklam.
+- Centralny odtwarzacz audio z wizualizacją i kontrolkami: play/pause, głośność, przełącznik jakości (128 kb/s).
+- Wyświetlana okładka i tytuł aktualnie granej piosenki.
+
+### 3. „Szept zza kurtyny”
+- Klimatyczna sekcja z animacją kurtyny w tle.
+- Cytat: „W czasie oskarżeń i manipulacji, czasem jeden, cichy głos może przywrócić perspektywę”.
+- Odtwarzacz nagrania z 2017 roku (czas trwania 12:34).
+
+### 4. Laboratorium AI: rekonstrukcja głosów
+- Panel edukacyjny nt. technologii Text-to-Speech.
+- **Rekonstrukcja AI #1:** analiza wzorców mowy z dokumentów z lat 2015–2018.
+- **Rekonstrukcja AI #2:** synteza emocjonalnych wzorców głosu.
+- Widoczne ostrzeżenie o etycznych aspektach użycia AI.
+- Osobne kontrolki audio dla każdej rekonstrukcji.
+
+### 5. Interaktywne poradniki: 8 grzechów toksycznych osób
+- Moduł Q&A z systemem progresu użytkownika.
+- Każdy z ośmiu „grzechów” zawiera: opis problemu, przykłady, pytania sprawdzające oraz punktację odpowiedzi.
+- Lista zagadnień:
+  1. Branie pieniędzy z instytucji zamiast prawdziwej pomocy.
+  2. Przerzucanie winy i granie ofiary.
+  3. Gaslighting.
+  4. Inwigilacja i obsesyjna kontrola.
+  5. Używanie instytucji jako broni.
+  6. Szantaż emocjonalny i groźby.
+  7. Tworzenie chaosu i dezinformacji.
+  8. Sianie podziałów i rozrywanie więzi.
+
+### 6. „Kocioł Wiedźmy”: pętla przemocy
+- Interaktywna wizualizacja cyklu w formie nieskończonej pętli.
+- Fazy: **Love Bombing → Dewaluacja → Odrzucenie → Hoovering** z podkreśleniem przepływu między segmentami „B” i „D”.
+- Edukacyjny opis manipulatorskiego cyklu relacji.
+
+### 7. Audycje analityczne: studium manipulacji
+- Dedykowany odtwarzacz z listą audycji i przyciskiem „Słuchaj” przy każdej pozycji.
+- Kategorie archiwalne: „Analiza Aktu Darowania”, „Służebność Uwiązania pod Piaszczem Prawa”, „Sprawa Adamskich: Wprowadzenie”, „Książę Niewdzięczność: Broń Narcyza”, „Śledztwo: Jak Dokumentować Manipulacje?”.
+
+### 8. Biblioteka przypadków
+- Cztery moduły opisujące narzędzia manipulatora:
+  - *Sprawa Adamskich: Wprowadzenie* – historia manipulacji i przemocy psychicznej.
+  - *Analiza kalendarza: kronika eskalacji* – kamienie milowe zdarzeń.
+  - *„Książę Niewdzięczność”: broń narcyza* – jak teoria staje się narzędziem gaslightingu.
+  - *Śledztwo: jak dokumentować manipulacje?* – praktyczne wskazówki.
+
+### 9. Mitologia narcyza: budowanie fałszywej rzeczywistości
+- Sekcja symboliczna z czterema ikonami odpowiadającymi liczbom: **7**, **4**, **8**, **13**.
+- Objaśnienia metaforycznych etapów kreowania przemocy i kryzysu.
+
+### 10. Archiwum czerwonych flag
+- Katalog udokumentowanych przypadków: „Dar jako narzędzie kontroli”, „Zapiski jako dowody przemocy”, „Protokoły jako teatr absurdu”, „Cykl samego roku wzorców przemocy”.
+- Każdy wpis zawiera analizę i schematy przemocy psychicznej.
+
+### 11. Strefa interaktywna
+- **Głosy społeczności:** cytaty osób dotkniętych przemocą, moderowany system komentarzy.
+- **Symulator rozmowy z manipulatorem (AI):** chatbot edukacyjny z przyciskami *Reset* i *Analiza rozmowy*.
+- **Dziennik czerwonych flag:** kalendarz rejestrujący incydenty i wzorce zachowań.
+
+### 12. Studio Radia Adamowo
+- Cztery kluczowe audycje: „Zespół Radia Adamowo”, „Serce Radia”, „Ekspertka ds. psychologii”, „Witamy w Studiu”.
+- Podkreślenie profesjonalnego studia i edukacyjnej misji.
+
+### 13. Materiał dokumentalny
+- Odtwarzacz wideo z filmem „Sprawa z Adamowa: Autopsja rodzinnej wojny”.
+- Materiały źródłowe ułatwiające zrozumienie mechanizmów manipulacji.
+
+### 14. Ostateczna lekcja
+- Podsumowanie kluczowych wniosków.
+- Zasoby pomocowe i kontakty kryzysowe (800 120 002 – Niebieska Linia, 800 120 226 – Centrum Praw Kobiet).
+
+### 15. Stopka
+- Linki do dokumentacji, polityki prywatności, metodologii i źródeł.
+- Adnotacja: „Copyright © 2025 Radio Adamowo”.
+
+## Elementy interaktywne
+- Pełne kontrolki we wszystkich odtwarzaczach audio.
+- Przyciski „Słuchaj” przy audycjach oraz mechanizmy postępu w poradnikach.
+- Formularze kontaktowe, newsletter oraz animowana wizualizacja pętli przemocy.
+
+## Responsywność
+- Layout reagujący na różne rozdzielczości.
+- Na dużych ekranach karty układają się w wielokolumnowe siatki.
+- Pełna funkcjonalność na urządzeniach mobilnych.


### PR DESCRIPTION
## Summary
- add a user-facing document that captures the comprehensive Radio Adamowo site structure and visual direction

## Testing
- npm run lint
- npm run test *(fails: no test files present)*

------
https://chatgpt.com/codex/tasks/task_e_68daf4cfa90c8322863bcec630376b21