### PR TITLE
feat: add case library and narcissist mythology modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ Aplikacja uruchomi się pod adresem `http://localhost:5173`.
 - `src/state` – globalne store'y (Zustand, konteksty).
 - `src/i18n` – pliki tłumaczeń.
 
+## Moduły edukacyjne
+### Biblioteka Przypadków
+- Konfiguracja danych znajduje się w `src/features/library/library.data.ts`, a schemat typów w `src/features/library/library.schema.ts`.
+- Każdy wpis (`LibraryEntry`) zawiera klucze tłumaczeń (tytuł, streszczenie, treści, wskazówki) oraz opcjonalne osie czasu i materiały do pobrania.
+- Teksty przechowywane są w plikach `src/i18n/*.json` pod przestrzenią `library.entries.<nazwaPrzypadku>`.
+- Aby dodać nowy przypadek:
+  1. Dodaj identyfikator do typu `LibraryEntry['id']` w `library.schema.ts`.
+  2. Wprowadź rekord w `library.data.ts` z odpowiednimi kluczami tłumaczeń i tagami.
+  3. Uzupełnij treści we wszystkich plikach tłumaczeń (`pl.json`, `nl.json`, `en.json`).
+
+### Mitologia Narcyza
+- Dane symboli znajdują się w `src/features/mythology/mythology.data.ts`, a typy w `src/features/mythology/mythology.schema.ts`.
+- Każdy symbol (`MythSymbol`) przechowuje identyfikator, klucze do nagłówków, opis znaczenia, momenty występowania oraz działania profilaktyczne.
+- Ikony SVG zlokalizowane są w `src/features/mythology/icons` i mapowane przez pole `icon`.
+- Aby dodać nowy symbol:
+  1. Rozszerz typ `SymbolId` i pole `icon` (dodaj nową ikonę lub wskaż istniejącą).
+  2. Dodaj wpis do `mythology.data.ts` wraz z kluczami tłumaczeń.
+  3. Uzupełnij treści w `pl.json`, `nl.json` oraz `en.json` w przestrzeni `mythology.symbol.<id>`.
+
 ## Dostępność i i18n
 - Dostępne przełączniki motywu i języka.
 - Translacje dla PL/NL/EN z autodetekcją języka przeglądarki.

--- a/public/assets/docs/calendar-analysis-template.pdf
+++ b/public/assets/docs/calendar-analysis-template.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a467595846a1954e1f21a70145d7eb0aa1cff958b61042c7bf635cce164607c
+size 624

--- a/public/assets/docs/case-adamscy-checklist.pdf
+++ b/public/assets/docs/case-adamscy-checklist.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a467595846a1954e1f21a70145d7eb0aa1cff958b61042c7bf635cce164607c
+size 624

--- a/public/assets/docs/case-adamscy-report.pdf
+++ b/public/assets/docs/case-adamscy-report.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a467595846a1954e1f21a70145d7eb0aa1cff958b61042c7bf635cce164607c
+size 624

--- a/public/assets/docs/investigation-evidence-log.pdf
+++ b/public/assets/docs/investigation-evidence-log.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a467595846a1954e1f21a70145d7eb0aa1cff958b61042c7bf635cce164607c
+size 624

--- a/public/assets/docs/investigation-interview-guide.pdf
+++ b/public/assets/docs/investigation-interview-guide.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a467595846a1954e1f21a70145d7eb0aa1cff958b61042c7bf635cce164607c
+size 624

--- a/public/assets/docs/prince-ingratitude-reflection.pdf
+++ b/public/assets/docs/prince-ingratitude-reflection.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a467595846a1954e1f21a70145d7eb0aa1cff958b61042c7bf635cce164607c
+size 624

--- a/src/features/library/LibraryCard.tsx
+++ b/src/features/library/LibraryCard.tsx
@@ -1,0 +1,76 @@
+import clsx from 'clsx';
+import { motion } from 'framer-motion';
+import { useId } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { LibraryEntry } from './library.schema';
+
+type LibraryCardProps = {
+  entry: LibraryEntry;
+  isActive: boolean;
+  onSelect: (entry: LibraryEntry) => void;
+};
+
+export function LibraryCard({ entry, isActive, onSelect }: LibraryCardProps): JSX.Element {
+  const { t } = useTranslation();
+  const descriptionId = useId();
+
+  return (
+    <article
+      className={clsx(
+        'group relative flex flex-col justify-between overflow-hidden rounded-3xl border border-base-800 bg-base-925/80 p-6 transition-colors',
+        'shadow-[0_0_32px_rgba(10,14,39,0.45)] backdrop-blur-sm focus-within:border-accent-400',
+        isActive ? 'border-accent-400/80 bg-base-900/80' : 'hover:border-accent-500/40'
+      )}
+      aria-labelledby={`${entry.id}-title`}
+      aria-describedby={descriptionId}
+    >
+      <div className="space-y-4">
+        <div className="flex items-center justify-between gap-2">
+          <h3 id={`${entry.id}-title`} className="font-display text-xl font-semibold text-base-50">
+            {t(entry.titleKey)}
+          </h3>
+          <motion.span
+            aria-hidden="true"
+            className="h-2 w-2 rounded-full"
+            layout
+            transition={{ type: 'spring', stiffness: 260, damping: 26 }}
+            style={{ background: isActive ? '#ff6b35' : 'rgba(255, 107, 53, 0.35)' }}
+          />
+        </div>
+        <p id={descriptionId} className="text-sm leading-relaxed text-base-200">
+          {t(entry.summaryKey)}
+        </p>
+        {entry.tags?.length ? (
+          <ul className="flex flex-wrap gap-2" aria-label={t('library.tags.label')}>
+            {entry.tags.map((tag) => (
+              <li key={tag}>
+                <span className="inline-flex items-center rounded-full border border-accent-500/30 bg-accent-500/10 px-3 py-1 text-xs font-medium uppercase tracking-wide text-accent-200">
+                  {t(tag)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+      <div className="mt-6 flex items-center justify-end">
+        <button
+          type="button"
+          onClick={() => onSelect(entry)}
+          className={clsx(
+            'inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold transition',
+            'focus-visible:shadow-focus focus-visible:outline-none motion-safe:hover:translate-x-0.5',
+            isActive
+              ? 'border-accent-400 bg-accent-500 text-base-950'
+              : 'border-accent-500/60 bg-transparent text-accent-200 hover:border-accent-400 hover:text-accent-100'
+          )}
+          aria-pressed={isActive}
+          aria-label={`${t('library.view')} — ${t(entry.titleKey)}`}
+        >
+          <span>{t('library.view')}</span>
+          <span aria-hidden="true">→</span>
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/src/features/library/LibraryDetails.tsx
+++ b/src/features/library/LibraryDetails.tsx
@@ -1,0 +1,189 @@
+import clsx from 'clsx';
+import type { KeyboardEvent } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { LibraryEntry } from './library.schema';
+
+type LibraryDetailsProps = {
+  entry: LibraryEntry;
+};
+
+type TabId = 'summary' | 'timeline' | 'resources' | 'tips';
+
+export function LibraryDetails({ entry }: LibraryDetailsProps): JSX.Element {
+  const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState<TabId>('summary');
+  const tabRefs = useRef<Record<TabId, HTMLButtonElement | null>>({
+    summary: null,
+    timeline: null,
+    resources: null,
+    tips: null
+  });
+
+  useEffect(() => {
+    setActiveTab('summary');
+  }, [entry.id]);
+
+  const tabs = useMemo(
+    () =>
+      [
+        { id: 'summary', label: t('library.tabs.summary') },
+        { id: 'timeline', label: t('library.tabs.timeline') },
+        { id: 'resources', label: t('library.tabs.resources') },
+        { id: 'tips', label: t('library.tabs.tips') }
+      ] as Array<{ id: TabId; label: string }>,
+    [t]
+  );
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
+      return;
+    }
+    event.preventDefault();
+    const currentIndex = tabs.findIndex((tab) => tab.id === activeTab);
+    const direction = event.key === 'ArrowRight' ? 1 : -1;
+    const nextIndex = (currentIndex + direction + tabs.length) % tabs.length;
+    const nextTab = tabs[nextIndex];
+    setActiveTab(nextTab.id);
+    const nextButton = tabRefs.current[nextTab.id];
+    nextButton?.focus();
+  };
+
+  const renderSummary = () => (
+    <div className="space-y-4">
+      {entry.contentKeys.map((contentKey) => (
+        <p key={contentKey} className="text-base leading-relaxed text-base-100/90">
+          {t(contentKey)}
+        </p>
+      ))}
+    </div>
+  );
+
+  const renderTimeline = () => {
+    if (!entry.timeline?.length) {
+      return <p className="text-base-200">{t('library.empty.timeline')}</p>;
+    }
+
+    return (
+      <ol className="relative space-y-6 border-l border-accent-500/40 pl-6">
+        {entry.timeline.map((item, index) => (
+          <li key={`${item.title}-${index}`} className="relative">
+            <span className="absolute -left-[1.35rem] top-1.5 flex h-3 w-3 items-center justify-center rounded-full border border-accent-400 bg-base-950">
+              <span className="h-1.5 w-1.5 rounded-full bg-accent-400" />
+            </span>
+            <time className="text-xs uppercase tracking-wide text-accent-200">
+              {t(item.when)}
+            </time>
+            <p className="mt-2 text-base font-medium text-base-50">{t(item.title)}</p>
+            {item.note ? (
+              <p className="mt-1 text-sm text-base-200">{t(item.note)}</p>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    );
+  };
+
+  const renderResources = () => {
+    if (!entry.resources?.length) {
+      return <p className="text-base-200">{t('library.empty.resources')}</p>;
+    }
+
+    return (
+      <ul className="space-y-3">
+        {entry.resources.map((resource) => (
+          <li key={resource.url}>
+            <a
+              href={resource.url}
+              className="inline-flex items-center gap-2 rounded-full border border-accent-500/40 bg-base-925/70 px-4 py-2 text-sm font-medium text-accent-100 transition motion-safe:hover:border-accent-400 motion-safe:hover:text-accent-50 focus-visible:border-accent-300 focus-visible:shadow-focus"
+              download
+            >
+              <span aria-hidden="true">📄</span>
+              <span>{t(resource.label)}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    );
+  };
+
+  const renderTips = () => {
+    if (!entry.tipsKeys?.length) {
+      return <p className="text-base-200">{t('library.empty.tips')}</p>;
+    }
+
+    return (
+      <ul className="list-disc space-y-3 pl-6 text-base text-base-100/90">
+        {entry.tipsKeys.map((tipKey) => (
+          <li key={tipKey}>{t(tipKey)}</li>
+        ))}
+      </ul>
+    );
+  };
+
+  const panelContent: Record<TabId, JSX.Element> = {
+    summary: renderSummary(),
+    timeline: renderTimeline(),
+    resources: renderResources(),
+    tips: renderTips()
+  };
+
+  return (
+    <section
+      className="flex flex-col rounded-3xl border border-base-800 bg-gradient-to-br from-base-925/90 via-base-900/70 to-base-950/90 p-8 shadow-[0_0_48px_rgba(14,18,42,0.55)]"
+      aria-labelledby={`${entry.id}-details-title`}
+      role="region"
+    >
+      <header className="flex flex-col gap-2 border-b border-base-850 pb-4">
+        <div className="flex items-center justify-between gap-3">
+          <h3 id={`${entry.id}-details-title`} className="font-display text-2xl font-semibold text-base-50">
+            {t(entry.titleKey)}
+          </h3>
+          <span className="text-xs uppercase tracking-[0.3em] text-accent-200">{t('library.details')}</span>
+        </div>
+        <p className="max-w-2xl text-sm text-base-200">{t(entry.summaryKey)}</p>
+      </header>
+
+      <div
+        className="mt-6 flex flex-col gap-4"
+        role="tablist"
+        aria-label={t('library.tabs.label')}
+        onKeyDown={handleKeyDown}
+      >
+        <div className="flex flex-wrap gap-2">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              ref={(element) => {
+                tabRefs.current[tab.id] = element;
+              }}
+              type="button"
+              id={`library-tab-${tab.id}`}
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              aria-controls={`library-panel-${tab.id}`}
+              onClick={() => setActiveTab(tab.id)}
+              className={clsx(
+                'inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold transition focus-visible:shadow-focus',
+                activeTab === tab.id
+                  ? 'border-accent-400 bg-accent-500 text-base-950'
+                  : 'border-transparent bg-base-900/60 text-base-200 hover:border-accent-500/40 hover:text-accent-100'
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <div
+          id={`library-panel-${activeTab}`}
+          role="tabpanel"
+          aria-labelledby={`library-tab-${activeTab}`}
+          className="rounded-3xl border border-base-850/80 bg-base-925/60 p-6 text-base-100 shadow-inner"
+        >
+          {panelContent[activeTab]}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/library/LibrarySection.test.tsx
+++ b/src/features/library/LibrarySection.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import i18n from '../../i18n';
+import { LibrarySection } from './LibrarySection';
+
+describe('LibrarySection', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('pl');
+  });
+
+  const renderSection = () =>
+    render(
+      <I18nextProvider i18n={i18n}>
+        <LibrarySection />
+      </I18nextProvider>
+    );
+
+  it('renders four library cards and details for the first entry', () => {
+    renderSection();
+
+    expect(screen.getByRole('heading', { name: 'Biblioteka Przypadków' })).toBeInTheDocument();
+    const cards = screen.getAllByRole('button', { name: /Zobacz —/ });
+    expect(cards).toHaveLength(4);
+    expect(screen.getByRole('heading', { name: 'Sprawa Adamskich: Wprowadzenie' })).toBeInTheDocument();
+    expect(screen.getByText('Rodzina Adamskich zgłosiła serię subtelnych, lecz narastających aktów izolacji i dewaluacji ze strony głowy rodziny.')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Streszczenie' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('allows switching entries and tabs while keeping focus on the detail panel', () => {
+    const { container } = renderSection();
+    const secondCard = screen.getByRole('button', {
+      name: 'Zobacz — Analiza Kalendarza: Kronika Eskalacji'
+    });
+
+    fireEvent.click(secondCard);
+
+    const focusTarget = container.querySelector('[tabindex="-1"]') as HTMLElement | null;
+    expect(focusTarget).not.toBeNull();
+    expect(document.activeElement).toBe(focusTarget);
+
+    expect(screen.getByRole('heading', { name: 'Analiza Kalendarza: Kronika Eskalacji' })).toBeInTheDocument();
+
+    const timelineTab = screen.getByRole('tab', { name: 'Oś czasu' });
+    fireEvent.click(timelineTab);
+    expect(timelineTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('Dzień 14')).toBeInTheDocument();
+    expect(screen.getByText('Powtarza się cykl: prezent – milczenie – krytyka.')).toBeInTheDocument();
+
+    const tabList = screen.getByRole('tablist', { name: 'Zakładki treści biblioteki' });
+    fireEvent.keyDown(tabList, { key: 'ArrowRight' });
+    const resourcesTab = screen.getByRole('tab', { name: 'Materiały' });
+    expect(resourcesTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('link', { name: /Szablon kalendarza eskalacji/ })).toBeInTheDocument();
+  });
+
+  it('loads translations for supported languages', async () => {
+    for (const [lang, expected] of [
+      ['pl', 'Biblioteka Przypadków'],
+      ['en', 'Case Library'],
+      ['nl', 'Casusbibliotheek']
+    ] as const) {
+      await i18n.changeLanguage(lang);
+      const { unmount } = renderSection();
+      expect(
+        screen.getByRole('heading', { name: expected })
+      ).toBeInTheDocument();
+      unmount();
+    }
+  });
+});

--- a/src/features/library/LibrarySection.tsx
+++ b/src/features/library/LibrarySection.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { LibraryCard } from './LibraryCard';
+import { LibraryDetails } from './LibraryDetails';
+import { LIBRARY_ENTRIES } from './library.data';
+import type { LibraryEntry } from './library.schema';
+
+type LibrarySectionProps = {
+  sectionId?: string;
+};
+
+export function LibrarySection({ sectionId }: LibrarySectionProps = {}): JSX.Element {
+  const { t } = useTranslation();
+  const [selectedEntry, setSelectedEntry] = useState<LibraryEntry>(LIBRARY_ENTRIES[0]);
+  const detailsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    detailsRef.current?.focus();
+  }, [selectedEntry.id]);
+
+  const cards = useMemo(
+    () =>
+      LIBRARY_ENTRIES.map((entry) => (
+        <LibraryCard
+          key={entry.id}
+          entry={entry}
+          isActive={selectedEntry.id === entry.id}
+          onSelect={setSelectedEntry}
+        />
+      )),
+    [selectedEntry.id]
+  );
+
+  return (
+    <section
+      id={sectionId}
+      role="region"
+      aria-labelledby="library-section-title"
+      className="space-y-8 rounded-[2.5rem] border border-base-900 bg-gradient-to-br from-base-950/95 via-base-925/80 to-base-950/95 p-8 shadow-[0_0_64px_rgba(9,12,32,0.6)]"
+    >
+      <header className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.4em] text-accent-200">{t('library.kicker')}</p>
+        <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <h2 id="library-section-title" className="font-display text-3xl font-semibold text-base-50 sm:text-4xl">
+            {t('library.title')}
+          </h2>
+          <p className="max-w-xl text-sm text-base-200">{t('library.intro')}</p>
+        </div>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2" aria-label={t('library.gridLabel')}>
+          {cards}
+        </div>
+        <div ref={detailsRef} tabIndex={-1} className="outline-none focus-visible:shadow-focus">
+          <LibraryDetails entry={selectedEntry} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/library/library.data.ts
+++ b/src/features/library/library.data.ts
@@ -1,0 +1,158 @@
+import type { LibraryEntry } from './library.schema';
+
+export const LIBRARY_ENTRIES: LibraryEntry[] = [
+  {
+    id: 'case_adamscy',
+    titleKey: 'library.entries.caseAdamscy.title',
+    summaryKey: 'library.entries.caseAdamscy.summary',
+    contentKeys: [
+      'library.entries.caseAdamscy.content.0',
+      'library.entries.caseAdamscy.content.1',
+      'library.entries.caseAdamscy.content.2'
+    ],
+    tipsKeys: [
+      'library.entries.caseAdamscy.tips.0',
+      'library.entries.caseAdamscy.tips.1',
+      'library.entries.caseAdamscy.tips.2'
+    ],
+    timeline: [
+      {
+        when: 'library.entries.caseAdamscy.timeline.0.when',
+        title: 'library.entries.caseAdamscy.timeline.0.title',
+        note: 'library.entries.caseAdamscy.timeline.0.note'
+      },
+      {
+        when: 'library.entries.caseAdamscy.timeline.1.when',
+        title: 'library.entries.caseAdamscy.timeline.1.title',
+        note: 'library.entries.caseAdamscy.timeline.1.note'
+      },
+      {
+        when: 'library.entries.caseAdamscy.timeline.2.when',
+        title: 'library.entries.caseAdamscy.timeline.2.title'
+      }
+    ],
+    resources: [
+      {
+        label: 'library.entries.caseAdamscy.resources.0',
+        url: '/assets/docs/case-adamscy-report.pdf'
+      },
+      {
+        label: 'library.entries.caseAdamscy.resources.1',
+        url: '/assets/docs/case-adamscy-checklist.pdf'
+      }
+    ],
+    tags: ['library.tags.caseStudy', 'library.tags.escalation', 'library.tags.family']
+  },
+  {
+    id: 'calendar_analysis',
+    titleKey: 'library.entries.calendarAnalysis.title',
+    summaryKey: 'library.entries.calendarAnalysis.summary',
+    contentKeys: [
+      'library.entries.calendarAnalysis.content.0',
+      'library.entries.calendarAnalysis.content.1',
+      'library.entries.calendarAnalysis.content.2'
+    ],
+    tipsKeys: [
+      'library.entries.calendarAnalysis.tips.0',
+      'library.entries.calendarAnalysis.tips.1',
+      'library.entries.calendarAnalysis.tips.2'
+    ],
+    timeline: [
+      {
+        when: 'library.entries.calendarAnalysis.timeline.0.when',
+        title: 'library.entries.calendarAnalysis.timeline.0.title',
+        note: 'library.entries.calendarAnalysis.timeline.0.note'
+      },
+      {
+        when: 'library.entries.calendarAnalysis.timeline.1.when',
+        title: 'library.entries.calendarAnalysis.timeline.1.title',
+        note: 'library.entries.calendarAnalysis.timeline.1.note'
+      },
+      {
+        when: 'library.entries.calendarAnalysis.timeline.2.when',
+        title: 'library.entries.calendarAnalysis.timeline.2.title'
+      }
+    ],
+    resources: [
+      {
+        label: 'library.entries.calendarAnalysis.resources.0',
+        url: '/assets/docs/calendar-analysis-template.pdf'
+      }
+    ],
+    tags: ['library.tags.timeline', 'library.tags.data', 'library.tags.patterns']
+  },
+  {
+    id: 'prince_ingratitude',
+    titleKey: 'library.entries.princeIngratitude.title',
+    summaryKey: 'library.entries.princeIngratitude.summary',
+    contentKeys: [
+      'library.entries.princeIngratitude.content.0',
+      'library.entries.princeIngratitude.content.1',
+      'library.entries.princeIngratitude.content.2'
+    ],
+    tipsKeys: [
+      'library.entries.princeIngratitude.tips.0',
+      'library.entries.princeIngratitude.tips.1',
+      'library.entries.princeIngratitude.tips.2'
+    ],
+    timeline: [
+      {
+        when: 'library.entries.princeIngratitude.timeline.0.when',
+        title: 'library.entries.princeIngratitude.timeline.0.title'
+      },
+      {
+        when: 'library.entries.princeIngratitude.timeline.1.when',
+        title: 'library.entries.princeIngratitude.timeline.1.title',
+        note: 'library.entries.princeIngratitude.timeline.1.note'
+      }
+    ],
+    resources: [
+      {
+        label: 'library.entries.princeIngratitude.resources.0',
+        url: '/assets/docs/prince-ingratitude-reflection.pdf'
+      }
+    ],
+    tags: ['library.tags.tactics', 'library.tags.narcissism', 'library.tags.relationships']
+  },
+  {
+    id: 'investigation_docs',
+    titleKey: 'library.entries.investigationDocs.title',
+    summaryKey: 'library.entries.investigationDocs.summary',
+    contentKeys: [
+      'library.entries.investigationDocs.content.0',
+      'library.entries.investigationDocs.content.1',
+      'library.entries.investigationDocs.content.2'
+    ],
+    tipsKeys: [
+      'library.entries.investigationDocs.tips.0',
+      'library.entries.investigationDocs.tips.1',
+      'library.entries.investigationDocs.tips.2'
+    ],
+    timeline: [
+      {
+        when: 'library.entries.investigationDocs.timeline.0.when',
+        title: 'library.entries.investigationDocs.timeline.0.title'
+      },
+      {
+        when: 'library.entries.investigationDocs.timeline.1.when',
+        title: 'library.entries.investigationDocs.timeline.1.title',
+        note: 'library.entries.investigationDocs.timeline.1.note'
+      },
+      {
+        when: 'library.entries.investigationDocs.timeline.2.when',
+        title: 'library.entries.investigationDocs.timeline.2.title'
+      }
+    ],
+    resources: [
+      {
+        label: 'library.entries.investigationDocs.resources.0',
+        url: '/assets/docs/investigation-evidence-log.pdf'
+      },
+      {
+        label: 'library.entries.investigationDocs.resources.1',
+        url: '/assets/docs/investigation-interview-guide.pdf'
+      }
+    ],
+    tags: ['library.tags.documentation', 'library.tags.procedures', 'library.tags.community']
+  }
+];

--- a/src/features/library/library.schema.ts
+++ b/src/features/library/library.schema.ts
@@ -1,0 +1,13 @@
+export type LibraryDocLink = { label: string; url: string };
+export type LibraryTimelineItem = { when: string; title: string; note?: string };
+
+export type LibraryEntry = {
+  id: 'case_adamscy' | 'calendar_analysis' | 'prince_ingratitude' | 'investigation_docs';
+  titleKey: string;
+  summaryKey: string;
+  contentKeys: string[];
+  tipsKeys?: string[];
+  timeline?: LibraryTimelineItem[];
+  resources?: LibraryDocLink[];
+  tags?: string[];
+};

--- a/src/features/mythology/MythologySection.test.tsx
+++ b/src/features/mythology/MythologySection.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import i18n from '../../i18n';
+import { MythologySection } from './MythologySection';
+
+describe('MythologySection', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('pl');
+  });
+
+  const renderSection = () =>
+    render(
+      <I18nextProvider i18n={i18n}>
+        <MythologySection />
+      </I18nextProvider>
+    );
+
+  it('renders four symbols and details for symbol 7', () => {
+    renderSection();
+
+    expect(screen.getByRole('heading', { name: 'Mitologia Narcyza' })).toBeInTheDocument();
+    const symbolButtons = screen.getAllByRole('button', { name: /Zobacz symbol/ });
+    expect(symbolButtons).toHaveLength(4);
+    expect(screen.getByRole('button', { name: 'Siedem — Zobacz symbol' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Siedem' })).toBeInTheDocument();
+    expect(screen.getByText('Obietnica wyjątkowego porozumienia ponad normami społecznymi.')).toBeInTheDocument();
+  });
+
+  it('switches symbols and moves focus to the detail panel', () => {
+    const { container } = renderSection();
+
+    const symbolFour = screen.getByRole('button', { name: 'Cztery — Zobacz symbol' });
+    fireEvent.click(symbolFour);
+
+    const focusTarget = container.querySelector('[tabindex="-1"]') as HTMLElement | null;
+    expect(focusTarget).not.toBeNull();
+    expect(document.activeElement).toBe(focusTarget);
+
+    expect(screen.getByRole('heading', { name: 'Cztery' })).toBeInTheDocument();
+    expect(symbolFour).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('Gdy wsparcie finansowe wiąże się z raportowaniem każdej wydanej złotówki.')).toBeInTheDocument();
+  });
+
+  it('supports translations for PL, EN and NL', async () => {
+    for (const [lang, expected] of [
+      ['pl', 'Mitologia Narcyza'],
+      ['en', 'Mythology of the Narcissist'],
+      ['nl', 'Mythologie van de narcist']
+    ] as const) {
+      await i18n.changeLanguage(lang);
+      const { unmount } = renderSection();
+      expect(screen.getByRole('heading', { name: expected })).toBeInTheDocument();
+      unmount();
+    }
+  });
+});

--- a/src/features/mythology/MythologySection.tsx
+++ b/src/features/mythology/MythologySection.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { SymbolCard } from './SymbolCard';
+import { SymbolDetails } from './SymbolDetails';
+import { MYTH_SYMBOLS } from './mythology.data';
+import type { MythSymbol } from './mythology.schema';
+
+type MythologySectionProps = {
+  sectionId?: string;
+};
+
+export function MythologySection({ sectionId }: MythologySectionProps = {}): JSX.Element {
+  const { t } = useTranslation();
+  const [selectedSymbol, setSelectedSymbol] = useState<MythSymbol>(MYTH_SYMBOLS[0]);
+  const detailsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    detailsRef.current?.focus();
+  }, [selectedSymbol.id]);
+
+  const cards = useMemo(
+    () =>
+      MYTH_SYMBOLS.map((symbol) => (
+        <SymbolCard
+          key={symbol.id}
+          symbol={symbol}
+          isActive={selectedSymbol.id === symbol.id}
+          onSelect={setSelectedSymbol}
+        />
+      )),
+    [selectedSymbol.id]
+  );
+
+  return (
+    <section
+      id={sectionId}
+      role="region"
+      aria-labelledby="mythology-section-title"
+      className="space-y-8 rounded-[2.5rem] border border-base-925 bg-gradient-to-br from-base-950 via-base-925/80 to-base-950 p-8 shadow-[0_0_70px_rgba(8,12,28,0.6)]"
+    >
+      <header className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.4em] text-accent-200">{t('mythology.kicker')}</p>
+        <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <h2 id="mythology-section-title" className="font-display text-3xl font-semibold text-base-50 sm:text-4xl">
+            {t('mythology.title')}
+          </h2>
+          <p className="max-w-xl text-sm text-base-200">{t('mythology.intro')}</p>
+        </div>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.1fr)]">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2" aria-label={t('mythology.gridLabel')}>
+          {cards}
+        </div>
+        <div ref={detailsRef} tabIndex={-1} className="outline-none focus-visible:shadow-focus">
+          <SymbolDetails symbol={selectedSymbol} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/mythology/SymbolCard.tsx
+++ b/src/features/mythology/SymbolCard.tsx
@@ -1,0 +1,61 @@
+import clsx from 'clsx';
+import { motion } from 'framer-motion';
+import type { ComponentProps } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { MythSymbol } from './mythology.schema';
+import { EightIcon } from './icons/EightIcon';
+import { FourIcon } from './icons/FourIcon';
+import { SevenIcon } from './icons/SevenIcon';
+import { ThirteenIcon } from './icons/ThirteenIcon';
+
+type SymbolCardProps = {
+  symbol: MythSymbol;
+  isActive: boolean;
+  onSelect: (symbol: MythSymbol) => void;
+};
+
+const ICON_MAP = {
+  seven: SevenIcon,
+  four: FourIcon,
+  eight: EightIcon,
+  thirteen: ThirteenIcon
+} satisfies Record<MythSymbol['icon'], (props: ComponentProps<'svg'>) => JSX.Element>;
+
+export function SymbolCard({ symbol, isActive, onSelect }: SymbolCardProps): JSX.Element {
+  const { t } = useTranslation();
+  const Icon = ICON_MAP[symbol.icon];
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(symbol)}
+      className={clsx(
+        'relative flex flex-col items-start gap-4 overflow-hidden rounded-3xl border p-6 text-left transition',
+        'focus-visible:shadow-focus focus-visible:outline-none',
+        isActive
+          ? 'border-accent-400/80 bg-base-925'
+          : 'border-base-850/80 bg-base-950/60 hover:border-accent-500/50'
+      )}
+      aria-pressed={isActive}
+      aria-label={`${t(symbol.titleKey)} — ${t('mythology.viewSymbol')}`}
+    >
+      <motion.span
+        className="absolute inset-0 rounded-3xl bg-gradient-to-br from-accent-500/15 via-transparent to-accent-500/5"
+        animate={{ opacity: isActive ? 1 : 0.5 }}
+        transition={{ duration: 0.3 }}
+        aria-hidden="true"
+      />
+      <div className="relative flex items-center gap-4">
+        <span className="flex h-14 w-14 items-center justify-center rounded-2xl bg-base-900/90 shadow-[0_0_22px_rgba(255,107,53,0.35)]">
+          <Icon className="h-10 w-10" aria-hidden="true" />
+        </span>
+        <div className="space-y-1">
+          <p className="text-xs uppercase tracking-[0.4em] text-accent-200">{t('mythology.symbolCode', { code: symbol.id })}</p>
+          <h3 className="font-display text-xl font-semibold text-base-50">{t(symbol.titleKey)}</h3>
+          <p className="text-sm text-base-200">{t(symbol.subtitleKey)}</p>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/src/features/mythology/SymbolDetails.tsx
+++ b/src/features/mythology/SymbolDetails.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from 'react-i18next';
+
+import type { MythSymbol } from './mythology.schema';
+
+export function SymbolDetails({ symbol }: { symbol: MythSymbol }): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <section
+      className="space-y-6 rounded-3xl border border-base-900/80 bg-base-950/70 p-8 shadow-[0_0_42px_rgba(9,12,32,0.45)]"
+      role="region"
+      aria-labelledby={`symbol-${symbol.id}-title`}
+    >
+      <header className="space-y-2">
+        <p className="text-xs uppercase tracking-[0.35em] text-accent-200">{t('mythology.detailKicker')}</p>
+        <h3 id={`symbol-${symbol.id}-title`} className="font-display text-2xl font-semibold text-base-50">
+          {t(symbol.titleKey)}
+        </h3>
+        <p className="max-w-2xl text-sm text-base-200">{t(symbol.subtitleKey)}</p>
+      </header>
+
+      <div className="grid gap-6 md:grid-cols-3">
+        <article className="space-y-3 rounded-2xl border border-base-850/80 bg-base-925/60 p-6">
+          <h4 className="text-sm font-semibold uppercase tracking-wider text-accent-100">{t('mythology.blocks.meaning')}</h4>
+          <ul className="space-y-2 text-sm text-base-200">
+            {symbol.meaningKeys.map((key) => (
+              <li key={key}>{t(key)}</li>
+            ))}
+          </ul>
+        </article>
+        <article className="space-y-3 rounded-2xl border border-base-850/80 bg-base-925/60 p-6">
+          <h4 className="text-sm font-semibold uppercase tracking-wider text-accent-100">{t('mythology.blocks.when')}</h4>
+          <ul className="space-y-2 text-sm text-base-200">
+            {symbol.whenKeys.map((key) => (
+              <li key={key}>{t(key)}</li>
+            ))}
+          </ul>
+        </article>
+        <article className="space-y-3 rounded-2xl border border-accent-500/40 bg-base-925/60 p-6">
+          <h4 className="text-sm font-semibold uppercase tracking-wider text-accent-100">{t('mythology.blocks.actions')}</h4>
+          <ul className="space-y-2 text-sm text-base-100">
+            {symbol.actionKeys.map((key) => (
+              <li key={key}>{t(key)}</li>
+            ))}
+          </ul>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/src/features/mythology/icons/EightIcon.tsx
+++ b/src/features/mythology/icons/EightIcon.tsx
@@ -1,0 +1,29 @@
+import type { SVGProps } from 'react';
+
+export function EightIcon(props: SVGProps<SVGSVGElement>): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      role="img"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <defs>
+        <linearGradient id="eightGradient" x1="0%" x2="100%" y1="100%" y2="0%">
+          <stop offset="0%" stopColor="#24163a" stopOpacity="0.9" />
+          <stop offset="100%" stopColor="#ff6b35" stopOpacity="0.6" />
+        </linearGradient>
+      </defs>
+      <rect x="6" y="6" width="52" height="52" rx="14" fill="url(#eightGradient)" opacity="0.75" />
+      <path
+        d="M32 16c-6.5 0-12 4.2-12 9.5s5.5 9.5 12 9.5 12-4.2 12-9.5S38.5 16 32 16Zm0 13c-6.5 0-12 4.2-12 9.5S25.5 48 32 48s12-4.2 12-9.5S38.5 29 32 29Z"
+        fill="none"
+        stroke="#ffe7db"
+        strokeWidth="5"
+      />
+      <circle cx="32" cy="25" r="4" fill="#fff" opacity="0.5" />
+      <circle cx="32" cy="39" r="4" fill="#fff" opacity="0.5" />
+    </svg>
+  );
+}

--- a/src/features/mythology/icons/FourIcon.tsx
+++ b/src/features/mythology/icons/FourIcon.tsx
@@ -1,0 +1,30 @@
+import type { SVGProps } from 'react';
+
+export function FourIcon(props: SVGProps<SVGSVGElement>): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      role="img"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <defs>
+        <linearGradient id="fourGradient" x1="0%" x2="0%" y1="0%" y2="100%">
+          <stop offset="0%" stopColor="#ff6b35" stopOpacity="0.75" />
+          <stop offset="100%" stopColor="#d53e1f" stopOpacity="0.2" />
+        </linearGradient>
+      </defs>
+      <circle cx="32" cy="32" r="28" fill="url(#fourGradient)" opacity="0.7" />
+      <path
+        d="M22 38V18l20 26V18"
+        fill="none"
+        stroke="#ffd3c2"
+        strokeWidth="5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx="32" cy="38" r="5" fill="#fff" opacity="0.6" />
+    </svg>
+  );
+}

--- a/src/features/mythology/icons/SevenIcon.tsx
+++ b/src/features/mythology/icons/SevenIcon.tsx
@@ -1,0 +1,30 @@
+import type { SVGProps } from 'react';
+
+export function SevenIcon(props: SVGProps<SVGSVGElement>): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      role="img"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <defs>
+        <linearGradient id="sevenGradient" x1="0%" x2="100%" y1="0%" y2="100%">
+          <stop offset="0%" stopColor="#ff6b35" stopOpacity="0.8" />
+          <stop offset="100%" stopColor="#ffe0d6" stopOpacity="0.2" />
+        </linearGradient>
+      </defs>
+      <rect x="4" y="4" width="56" height="56" rx="10" ry="10" fill="url(#sevenGradient)" opacity="0.65" />
+      <path
+        d="M18 14h32l-20 36"
+        fill="none"
+        stroke="#ff8f60"
+        strokeWidth="6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M26 30h16" stroke="#fff" strokeWidth="3" strokeLinecap="round" opacity="0.6" />
+    </svg>
+  );
+}

--- a/src/features/mythology/icons/ThirteenIcon.tsx
+++ b/src/features/mythology/icons/ThirteenIcon.tsx
@@ -1,0 +1,29 @@
+import type { SVGProps } from 'react';
+
+export function ThirteenIcon(props: SVGProps<SVGSVGElement>): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      role="img"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <defs>
+        <radialGradient id="thirteenGradient" cx="50%" cy="50%" r="60%">
+          <stop offset="0%" stopColor="#ff6b35" stopOpacity="0.85" />
+          <stop offset="100%" stopColor="#0a0e27" stopOpacity="0.1" />
+        </radialGradient>
+      </defs>
+      <rect x="8" y="8" width="48" height="48" rx="12" fill="#131836" opacity="0.8" />
+      <path
+        d="M16 48L48 16m0 28-28-28"
+        stroke="url(#thirteenGradient)"
+        strokeWidth="6"
+        strokeLinecap="round"
+      />
+      <circle cx="24" cy="24" r="5" fill="#ffb79a" opacity="0.8" />
+      <circle cx="40" cy="40" r="5" fill="#ffb79a" opacity="0.8" />
+    </svg>
+  );
+}

--- a/src/features/mythology/mythology.data.ts
+++ b/src/features/mythology/mythology.data.ts
@@ -1,0 +1,82 @@
+import type { MythSymbol } from './mythology.schema';
+
+export const MYTH_SYMBOLS: MythSymbol[] = [
+  {
+    id: 7,
+    titleKey: 'mythology.symbol.7.title',
+    subtitleKey: 'mythology.symbol.7.subtitle',
+    meaningKeys: [
+      'mythology.symbol.7.meaning.0',
+      'mythology.symbol.7.meaning.1'
+    ],
+    whenKeys: [
+      'mythology.symbol.7.when.0',
+      'mythology.symbol.7.when.1',
+      'mythology.symbol.7.when.2'
+    ],
+    actionKeys: [
+      'mythology.symbol.7.action.0',
+      'mythology.symbol.7.action.1'
+    ],
+    icon: 'seven'
+  },
+  {
+    id: 4,
+    titleKey: 'mythology.symbol.4.title',
+    subtitleKey: 'mythology.symbol.4.subtitle',
+    meaningKeys: [
+      'mythology.symbol.4.meaning.0',
+      'mythology.symbol.4.meaning.1'
+    ],
+    whenKeys: [
+      'mythology.symbol.4.when.0',
+      'mythology.symbol.4.when.1'
+    ],
+    actionKeys: [
+      'mythology.symbol.4.action.0',
+      'mythology.symbol.4.action.1',
+      'mythology.symbol.4.action.2'
+    ],
+    icon: 'four'
+  },
+  {
+    id: 8,
+    titleKey: 'mythology.symbol.8.title',
+    subtitleKey: 'mythology.symbol.8.subtitle',
+    meaningKeys: [
+      'mythology.symbol.8.meaning.0',
+      'mythology.symbol.8.meaning.1',
+      'mythology.symbol.8.meaning.2'
+    ],
+    whenKeys: [
+      'mythology.symbol.8.when.0',
+      'mythology.symbol.8.when.1',
+      'mythology.symbol.8.when.2'
+    ],
+    actionKeys: [
+      'mythology.symbol.8.action.0',
+      'mythology.symbol.8.action.1'
+    ],
+    icon: 'eight'
+  },
+  {
+    id: 13,
+    titleKey: 'mythology.symbol.13.title',
+    subtitleKey: 'mythology.symbol.13.subtitle',
+    meaningKeys: [
+      'mythology.symbol.13.meaning.0',
+      'mythology.symbol.13.meaning.1'
+    ],
+    whenKeys: [
+      'mythology.symbol.13.when.0',
+      'mythology.symbol.13.when.1',
+      'mythology.symbol.13.when.2'
+    ],
+    actionKeys: [
+      'mythology.symbol.13.action.0',
+      'mythology.symbol.13.action.1',
+      'mythology.symbol.13.action.2'
+    ],
+    icon: 'thirteen'
+  }
+];

--- a/src/features/mythology/mythology.schema.ts
+++ b/src/features/mythology/mythology.schema.ts
@@ -1,0 +1,10 @@
+export type SymbolId = 7 | 4 | 8 | 13;
+export type MythSymbol = {
+  id: SymbolId;
+  titleKey: string;
+  subtitleKey: string;
+  meaningKeys: string[];
+  whenKeys: string[];
+  actionKeys: string[];
+  icon: 'seven' | 'four' | 'eight' | 'thirteen';
+};

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -10,29 +10,12 @@
     "lab": "Lab",
     "community": "Community"
   },
-  "pages": {
-    "home": {
-      "title": "Radio Adamowo",
-      "lead": "An educational radio about psychological abuse."
-    },
-    "live": {
-      "title": "Live Stream"
-    },
-    "guides": {
-      "title": "Guides"
-    },
-    "lab": {
-      "title": "AI Lab"
-    },
-    "community": {
-      "title": "Community"
-    },
-    "violenceLoop": {
-      "title": "Violence loop"
-    },
-    "shows": {
-      "title": "Shows"
-    }
+  "header": {
+    "skipToContent": "Skip to main content",
+    "openMenu": "Open menu",
+    "closeMenu": "Close menu",
+    "home": "Back to Radio Adamowo home",
+    "navigation": "Main navigation"
   },
   "controls": {
     "theme": {
@@ -47,4 +30,342 @@
       "resolved_dark": "dark mode",
       "resolved_light": "light mode"
     },
+    "language": {
+      "label": "Change language",
+      "pl": "Polish",
+      "nl": "Dutch",
+      "en": "English"
+    }
+  },
+  "pages": {
+    "home": {
+      "title": "Radio Adamowo",
+      "lead": "An educational radio about psychological abuse."
+    },
+    "live": {
+      "title": "Live Stream"
+    },
+    "guides": {
+      "title": "Guides",
+      "lede": "An educational hub about manipulation, narcissism and documenting psychological abuse.",
+      "anchorNav": "Guide section navigation",
+      "links": {
+        "library": "Case library",
+        "mythology": "Mythology of the Narcissist"
+      }
+    },
+    "lab": {
+      "title": "AI Lab"
+    },
+    "community": {
+      "title": "Community"
+    },
+    "violenceLoop": {
+      "title": "Violence loop"
+    },
+    "shows": {
+      "title": "Shows"
+    }
+  },
+  "player": {
+    "regionLabel": "Radio Adamowo player",
+    "artworkAlt": "Show artwork {{title}} — {{artist}}",
+    "live": "Live",
+    "buffering": "Buffering signal…",
+    "reconnecting": "Reconnecting ({{seconds}} s remaining)",
+    "error": "Unable to play the stream.",
+    "idle": "Player ready",
+    "nowPlaying": "Now playing",
+    "visualizerAria": "Audio waveform visualiser",
+    "play": "Play",
+    "pause": "Pause",
+    "mute": "Mute",
+    "unmute": "Unmute",
+    "quality_128kbps": "128 kbps",
+    "volume": "Volume",
+    "retry": "Try again"
+  },
+  "whisper": {
+    "regionLabel": "Whisper Behind the Curtain — reconstructed hearing",
+    "length": "Recording length",
+    "title": "Whisper Behind the Curtain",
+    "subtitle": "The recording captures a tense public hearing from 2017.",
+    "ethics": {
+      "title": "Ethical listening notes",
+      "body": [
+        "Listen with empathy — every breath belongs to a real person.",
+        "Pay attention to pauses and ellipses; power dynamics hide between the lines.",
+        "Write down facts, avoid judgments — the material serves education and prevention."
+      ]
+    },
+    "play": "Play",
+    "pause": "Pause",
+    "restart": "Start over",
+    "mute": "Mute",
+    "unmute": "Turn sound on",
+    "scrub": "Timeline",
+    "volume": "Volume",
+    "status": {
+      "paused": "Playback paused.",
+      "playing": "Playback running.",
+      "ended": "Recording finished.",
+      "error": "Unable to play the audio file.",
+      "restarted": "Restarted from the beginning.",
+      "seeked": "Playback position changed.",
+      "muted": "Sound muted.",
+      "unmuted": "Sound restored.",
+      "volume": "Volume set to {{value}}%"
+    }
+  },
+  "library": {
+    "kicker": "Case library",
+    "title": "Case Library",
+    "intro": "Four tools to decode narcissistic abuse: case study, calendar analysis, weaponised charm and documentation protocols.",
+    "gridLabel": "Library cards",
+    "view": "View",
+    "details": "Knowledge panel",
+    "tabs": {
+      "label": "Library tabs",
+      "summary": "Summary",
+      "timeline": "Timeline",
+      "resources": "Materials",
+      "tips": "Tips"
+    },
+    "empty": {
+      "timeline": "No events recorded in the timeline.",
+      "resources": "Materials will be available soon.",
+      "tips": "No extra tips for this entry."
+    },
+    "tags": {
+      "label": "Case tags",
+      "caseStudy": "case study",
+      "escalation": "escalation",
+      "family": "family",
+      "timeline": "timeline",
+      "data": "data",
+      "patterns": "patterns",
+      "tactics": "tactics",
+      "narcissism": "narcissism",
+      "relationships": "relationships",
+      "documentation": "documentation",
+      "procedures": "procedures",
+      "community": "support"
+    },
+    "entries": {
+      "caseAdamscy": {
+        "title": "The Adamski Case: Orientation",
+        "summary": "The Adamski family reported a subtle yet growing isolation and devaluation campaign by the head of the household.",
+        "content": [
+          "The analysis starts with daily observations: locked doors, hijacked conversations and tight control over the family schedule.",
+          "Attempts to fracture bonds appear — gifts for selected members, criticism of the rest and threats to cut off funds.",
+          "The turning point arrives when the youngest daughter logs remarks and neighbours confirm the behavioural shift."
+        ],
+        "tips": [
+          "Keep notes on everyday interactions, even the mundane ones.",
+          "Compare accounts from different family members — narcissists split people into factions.",
+          "Watch for sudden acts of kindness preceded by episodes of humiliation."
+        ],
+        "timeline": [
+          {
+            "when": "January 2020",
+            "title": "First signs of isolation",
+            "note": "The abuser takes over the children's schedule and limits online contact."
+          },
+          {
+            "when": "March 2020",
+            "title": "Escalated financial control",
+            "note": "Receipts are demanded and penalties issued for unapproved expenses."
+          },
+          {
+            "when": "June 2020",
+            "title": "Evidence review and intervention"
+          }
+        ],
+        "resources": [
+          "Adamski family observation report",
+          "Isolation warning checklist"
+        ]
+      },
+      "calendarAnalysis": {
+        "title": "Calendar Analysis: Chronicle of Escalation",
+        "summary": "A technique that records micro-events to reveal the full cycle of psychological abuse.",
+        "content": [
+          "Keep a daily log of incidents and tag them with colour codes according to the type of harm.",
+          "After 30 days, a frequency map emerges showing phases of idealisation, devaluation and silence.",
+          "Comparing the victim and abuser calendars exposes correlations between promises and punishments."
+        ],
+        "tips": [
+          "Use a single log to avoid losing track of data.",
+          "Add brief quotes or tone descriptions — critical for analysis.",
+          "Review entries weekly with a trusted person or therapist."
+        ],
+        "timeline": [
+          {
+            "when": "Day 1",
+            "title": "Observation starts",
+            "note": "Colour legend defined with an 'alert' category."
+          },
+          {
+            "when": "Day 14",
+            "title": "Patterns emerge",
+            "note": "Cycle repeats: gift – silence – criticism."
+          },
+          {
+            "when": "Day 30",
+            "title": "Report and debrief"
+          }
+        ],
+        "resources": [
+          "Escalation calendar template"
+        ]
+      },
+      "princeIngratitude": {
+        "title": "The Prince of Ingratitude: Narcissist Weapon",
+        "summary": "A strategy of suddenly withdrawing favour after idealisation to force complete submission.",
+        "content": [
+          "The narcissist scripts a fairy-tale scenario: promises of promotion, joint ventures or elevated status. The victim receives a 'prince' title.",
+          "Once trust is absolute, support disappears and public shaming follows.",
+          "The trap works because the victim defends an imagined status rather than the relationship itself."
+        ],
+        "tips": [
+          "Check whether offered privileges have legal or financial grounding.",
+          "Notice demands for gratitude without actual help.",
+          "Define your own success criteria instead of adopting the abuser's narrative."
+        ],
+        "timeline": [
+          {
+            "when": "Week 1",
+            "title": "Idealisation and titling"
+          },
+          {
+            "when": "Week 4",
+            "title": "Public removal of favour",
+            "note": "The victim is humiliated in front of witnesses."
+          }
+        ],
+        "resources": [
+          "Reflection exercise: decode the narcissist narrative"
+        ]
+      },
+      "investigationDocs": {
+        "title": "Investigation: Documenting Manipulation",
+        "summary": "A safe evidence-gathering protocol that avoids escalation while protecting the victim.",
+        "content": [
+          "Create an incident diary with dates, times and sources: texts, emails, voice notes.",
+          "Set up a storage protocol — encrypted cloud or offline drive.",
+          "Add third-party statements and institutional records (school, doctor, employer)."
+        ],
+        "tips": [
+          "Use consistent file names: date_location_event.",
+          "Do not alert the abuser if retaliation is likely.",
+          "Partner with local support groups to secure legal backup."
+        ],
+        "timeline": [
+          {
+            "when": "Week 1",
+            "title": "Incident log created"
+          },
+          {
+            "when": "Week 3",
+            "title": "Evidence review",
+            "note": "Materials shared with a mediator."
+          },
+          {
+            "when": "Week 6",
+            "title": "Report prepared for institutions"
+          }
+        ],
+        "resources": [
+          "Evidence log worksheet",
+          "Witness interview guide"
+        ]
+      }
+    }
+  },
+  "mythology": {
+    "kicker": "Mythology of the narcissist",
+    "title": "Mythology of the Narcissist",
+    "intro": "Four warning symbols describing control cycles: 7 — ideal pact, 4 — dependency grid, 8 — return loop, 13 — rupture alert.",
+    "gridLabel": "Narcissist mythology symbols",
+    "viewSymbol": "View symbol",
+    "symbolCode": "Symbol {{code}}",
+    "detailKicker": "Decoding the symbol",
+    "blocks": {
+      "meaning": "What it means",
+      "when": "When it appears",
+      "actions": "How to respond"
+    },
+    "symbol": {
+      "7": {
+        "title": "Seven",
+        "subtitle": "Symbol of the perfect pact",
+        "meaning": [
+          "Promise of an exceptional agreement beyond social norms.",
+          "Declarations of total loyalty in exchange for control."
+        ],
+        "when": [
+          "When the narcissist proposes a secret collaboration or 'special' deal.",
+          "During sudden gifts after conflict periods.",
+          "Right before asking for a risky act of loyalty."
+        ],
+        "action": [
+          "Ask about real consequences and request time to reflect.",
+          "Consult a trusted person before accepting the terms."
+        ]
+      },
+      "4": {
+        "title": "Four",
+        "subtitle": "Symbol of the closed network",
+        "meaning": [
+          "Four pillars of dependency: emotions, money, reputation, access to loved ones.",
+          "Signals a setup where every choice has four control levers."
+        ],
+        "when": [
+          "When financial help requires reporting every expense.",
+          "When the abuser dictates who may be your friend."
+        ],
+        "action": [
+          "Map alternative support outside the abuser.",
+          "Split dependencies: separate budget, alternate communication channels.",
+          "Secure at least one pillar today."
+        ]
+      },
+      "8": {
+        "title": "Eight",
+        "subtitle": "Symbol of the return loop",
+        "meaning": [
+          "Endless promise of improvement.",
+          "Highlights the cycle: 'never again' turns into 'again'.",
+          "Refers to addictive break-up/make-up dynamics."
+        ],
+        "when": [
+          "After a breakup when therapy or drastic change is promised immediately.",
+          "When the meeting schedule looks like a sine wave.",
+          "Right after the victim states boundaries or ultimatums."
+        ],
+        "action": [
+          "Write down conditions for return and schedule a progress review date.",
+          "Track real change, not declarations."
+        ]
+      },
+      "13": {
+        "title": "Thirteen",
+        "subtitle": "Symbol of rupture and alarm",
+        "meaning": [
+          "Announces a drastic cut-off often used as a threat.",
+          "May signal escalation toward economic or legal abuse."
+        ],
+        "when": [
+          "When the abuser threatens custody or asset seizure.",
+          "As the victim prepares to leave or disclose evidence.",
+          "Right before major events: holidays, contracts, moving."
+        ],
+        "action": [
+          "Secure documents and emergency contacts.",
+          "Alert a trusted person about potential escalation.",
+          "Draft a safety plan and review local resources."
+        ]
+      }
+    }
+  }
 }

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -5,21 +5,54 @@
   "navigation": {
     "live": "Live",
     "violenceLoop": "Geweldscyclus",
-    "shows": "Uitzendingen",
+    "shows": "Programma's",
     "guide": "Gids",
-    "lab": "Laboratorium",
+    "lab": "Lab",
     "community": "Gemeenschap"
+  },
+  "header": {
+    "skipToContent": "Ga naar de hoofdinhoud",
+    "openMenu": "Menu openen",
+    "closeMenu": "Menu sluiten",
+    "home": "Terug naar Radio Adamowo",
+    "navigation": "Hoofdnavigatie"
+  },
+  "controls": {
+    "theme": {
+      "label": "Thema",
+      "system": "Systeemthema",
+      "systemShort": "SYS",
+      "light": "Lichte modus",
+      "lightShort": "LGT",
+      "dark": "Donkere modus",
+      "darkShort": "DRK",
+      "current": "Huidig: {{value}}",
+      "resolved_dark": "donkere modus",
+      "resolved_light": "lichte modus"
+    },
+    "language": {
+      "label": "Taal wijzigen",
+      "pl": "Pools",
+      "nl": "Nederlands",
+      "en": "Engels"
+    }
   },
   "pages": {
     "home": {
       "title": "Radio Adamowo",
-      "lead": "Educatieve radio over psychologisch misbruik."
+      "lead": "Een educatieve radio over psychologisch geweld."
     },
     "live": {
       "title": "Livestream"
     },
     "guides": {
-      "title": "Gidsen"
+      "title": "Gidsen",
+      "lede": "Kenniscentrum over manipulatie, narcisme en het documenteren van psychologisch geweld.",
+      "anchorNav": "Navigatie door de gids",
+      "links": {
+        "library": "Casusbibliotheek",
+        "mythology": "Mythologie van de narcist"
+      }
     },
     "lab": {
       "title": "AI-lab"
@@ -31,20 +64,308 @@
       "title": "Geweldscyclus"
     },
     "shows": {
-      "title": "Uitzendingen"
+      "title": "Programma's"
     }
   },
-  "controls": {
-    "theme": {
-      "label": "Thema",
-      "system": "Systeemthema",
-      "systemShort": "SYS",
-      "light": "Lichte modus",
-      "lightShort": "LIC",
-      "dark": "Donkere modus",
-      "darkShort": "DON",
-      "current": "Actueel: {{value}}",
-      "resolved_dark": "donkere modus",
-      "resolved_light": "lichte modus"
+  "player": {
+    "regionLabel": "Radio Adamowo-speler",
+    "artworkAlt": "Programmahoes {{title}} — {{artist}}",
+    "live": "Live",
+    "buffering": "Signaal wordt geladen…",
+    "reconnecting": "Opnieuw verbinden (nog {{seconds}} s)",
+    "error": "Stream kan niet worden afgespeeld.",
+    "idle": "Speler klaar",
+    "nowPlaying": "Speelt nu",
+    "visualizerAria": "Visualisatie van geluidsgolven",
+    "play": "Afspelen",
+    "pause": "Pauze",
+    "mute": "Dempen",
+    "unmute": "Dempen opheffen",
+    "quality_128kbps": "128 kbps",
+    "volume": "Volume",
+    "retry": "Opnieuw proberen"
+  },
+  "whisper": {
+    "regionLabel": "Fluistering achter het gordijn — gereconstrueerde hoorzitting",
+    "length": "Duur van de opname",
+    "title": "Fluistering achter het gordijn",
+    "subtitle": "De opname legt een gespannen openbare hoorzitting uit 2017 vast.",
+    "ethics": {
+      "title": "Ethische luisternotities",
+      "body": [
+        "Luister met empathie — elke zucht is van een echt persoon.",
+        "Let op pauzes en stiltes; machtsdynamiek zit tussen de regels.",
+        "Noteer feiten en vermijd oordelen — het materiaal dient onderwijs en preventie."
+      ]
     },
+    "play": "Afspelen",
+    "pause": "Pauze",
+    "restart": "Opnieuw starten",
+    "mute": "Dempen",
+    "unmute": "Geluid aan",
+    "scrub": "Tijdlijn",
+    "volume": "Volume",
+    "status": {
+      "paused": "Afspelen gepauzeerd.",
+      "playing": "Afspelen actief.",
+      "ended": "Opname beëindigd.",
+      "error": "Audiobestand kan niet worden afgespeeld.",
+      "restarted": "Opnieuw gestart vanaf het begin.",
+      "seeked": "Afspelpositie gewijzigd.",
+      "muted": "Geluid gedempt.",
+      "unmuted": "Geluid hersteld.",
+      "volume": "Volume ingesteld op {{value}}%"
+    }
+  },
+  "library": {
+    "kicker": "Casusbibliotheek",
+    "title": "Casusbibliotheek",
+    "intro": "Vier instrumenten om narcistisch geweld te doorgronden: casusstudie, kalenderscan, wapenarsenaal en documentatieprocedures.",
+    "gridLabel": "Kaarten van de bibliotheek",
+    "view": "Bekijken",
+    "details": "Kennispaneel",
+    "tabs": {
+      "label": "Bibliotheek-tabbladen",
+      "summary": "Samenvatting",
+      "timeline": "Tijdlijn",
+      "resources": "Materialen",
+      "tips": "Tips"
+    },
+    "empty": {
+      "timeline": "Geen gebeurtenissen vastgelegd.",
+      "resources": "Materialen volgen binnenkort.",
+      "tips": "Geen extra tips voor dit dossier."
+    },
+    "tags": {
+      "label": "Casustags",
+      "caseStudy": "casus",
+      "escalation": "escalatie",
+      "family": "familie",
+      "timeline": "tijdlijn",
+      "data": "data",
+      "patterns": "patronen",
+      "tactics": "tactieken",
+      "narcissism": "narcisme",
+      "relationships": "relaties",
+      "documentation": "documentatie",
+      "procedures": "procedures",
+      "community": "steun"
+    },
+    "entries": {
+      "caseAdamscy": {
+        "title": "Zaak Adamski: introductie",
+        "summary": "Familie Adamski meldde een subtiele maar groeiende campagne van isolatie en devaluatie door het gezinshoofd.",
+        "content": [
+          "De analyse begint met dagelijkse observaties: afgesloten deuren, afgebroken gesprekken en strakke controle over het familieschema.",
+          "Er verschijnen pogingen om banden te breken — cadeaus voor enkelen, kritiek op de rest en dreiging om geldstromen stop te zetten.",
+          "Het kantelpunt komt wanneer de jongste dochter opmerkingen vastlegt en buren het veranderde gedrag bevestigen."
+        ],
+        "tips": [
+          "Noteer dagelijkse interacties, hoe klein ook.",
+          "Vergelijk getuigenissen van verschillende gezinsleden — narcisten splijten hun omgeving.",
+          "Let op plotselinge vriendelijkheid na perioden van vernedering."
+        ],
+        "timeline": [
+          {
+            "when": "Januari 2020",
+            "title": "Eerste signalen van isolatie",
+            "note": "De dader neemt het schema van de kinderen over en beperkt online contact."
+          },
+          {
+            "when": "Maart 2020",
+            "title": "Verscherpte financiële controle",
+            "note": "Bonnetjes worden geëist en ongeplande uitgaven bestraft."
+          },
+          {
+            "when": "Juni 2020",
+            "title": "Bewijs verzameld en interventie"
+          }
+        ],
+        "resources": [
+          "Observatierapport familie Adamski",
+          "Checklist signalen van isolatie"
+        ]
+      },
+      "calendarAnalysis": {
+        "title": "Kalenderanalyse: kroniek van escalatie",
+        "summary": "Techniek om microgebeurtenissen vast te leggen en de volledige cyclus van psychologisch geweld zichtbaar te maken.",
+        "content": [
+          "Houd een dagelijks logboek bij en markeer gebeurtenissen met kleuren per soort misbruik.",
+          "Na 30 dagen ontstaat een frequentiekaart die idealisatie, devaluatie en stilte toont.",
+          "Door kalenders van slachtoffer en dader te vergelijken, worden verbanden tussen beloften en straffen zichtbaar."
+        ],
+        "tips": [
+          "Gebruik één vaste plek voor notities om overzicht te bewaren.",
+          "Voeg korte citaten of toonbeschrijvingen toe — essentieel voor de analyse.",
+          "Bespreek wekelijks de notities met een vertrouwenspersoon of therapeut."
+        ],
+        "timeline": [
+          {
+            "when": "Dag 1",
+            "title": "Start observatie",
+            "note": "Kleurlegenda opgesteld met een 'alarm'-categorie."
+          },
+          {
+            "when": "Dag 14",
+            "title": "Patronen zichtbaar",
+            "note": "Cyclus herhaalt: cadeau – stilte – kritiek."
+          },
+          {
+            "when": "Dag 30",
+            "title": "Rapport en nabespreking"
+          }
+        ],
+        "resources": [
+          "Template escalatiekalender"
+        ]
+      },
+      "princeIngratitude": {
+        "title": "'Prins Ondankbaar': wapen van de narcist",
+        "summary": "Strategie waarbij gunst abrupt wordt ingetrokken na idealisatie om volledige onderwerping af te dwingen.",
+        "content": [
+          "De narcist bouwt een sprookjesscenario: beloften van promotie, gezamenlijke projecten of status. Het slachtoffer krijgt een 'prinstitel'.",
+          "Wanneer het vertrouwen totaal is, verdwijnt steun en volgt publieke vernedering.",
+          "Het werkt omdat het slachtoffer een denkbeeldige status verdedigt in plaats van de relatie zelf."
+        ],
+        "tips": [
+          "Controleer of beloofde privileges juridisch of financieel onderbouwd zijn.",
+          "Let op eisen tot dankbaarheid zonder echte hulp.",
+          "Bepaal eigen succescriteria in plaats van de narratief van de dader te volgen."
+        ],
+        "timeline": [
+          {
+            "when": "Week 1",
+            "title": "Idealiserende start"
+          },
+          {
+            "when": "Week 4",
+            "title": "Publiek ontnemen van gunst",
+            "note": "Het slachtoffer wordt belachelijk gemaakt voor getuigen."
+          }
+        ],
+        "resources": [
+          "Reflectie-oefening: ontmasker de narratief van de narcist"
+        ]
+      },
+      "investigationDocs": {
+        "title": "Onderzoek: manipulaties documenteren",
+        "summary": "Veilig protocol om bewijs te verzamelen zonder escalatie en met bescherming van het slachtoffer.",
+        "content": [
+          "Houd een incidentenlog bij met datum, tijd en bron: sms, e-mail, spraakmemo.",
+          "Leg een opslagprotocol vast — versleutelde cloud of offline drager.",
+          "Voeg verklaringen van derden en officiële documenten (school, arts, werkgever) toe."
+        ],
+        "tips": [
+          "Gebruik consistente bestandsnamen: datum_locatie_gebeurtenis.",
+          "Informeer de dader niet als dit wraak kan uitlokken.",
+          "Werk samen met lokale steunpunten voor juridische rugdekking."
+        ],
+        "timeline": [
+          {
+            "when": "Week 1",
+            "title": "Start incidentenlog"
+          },
+          {
+            "when": "Week 3",
+            "title": "Bewijsreview",
+            "note": "Materiaal gedeeld met mediator."
+          },
+          {
+            "when": "Week 6",
+            "title": "Rapport voor instanties"
+          }
+        ],
+        "resources": [
+          "Werkblad bewijslijst",
+          "Handleiding getuigeninterviews"
+        ]
+      }
+    }
+  },
+  "mythology": {
+    "kicker": "Mythologie van de narcist",
+    "title": "Mythologie van de narcist",
+    "intro": "Vier waarschuwingssymbolen voor controle: 7 — ideaal pact, 4 — afhankelijkheidsnet, 8 — terugkeerlus, 13 — alarmsignaal.",
+    "gridLabel": "Symbolen van de narcist",
+    "viewSymbol": "Bekijk symbool",
+    "symbolCode": "Symbool {{code}}",
+    "detailKicker": "Het symbool ontcijferen",
+    "blocks": {
+      "meaning": "Betekenis",
+      "when": "Wanneer zichtbaar",
+      "actions": "Aanpak"
+    },
+    "symbol": {
+      "7": {
+        "title": "Zeven",
+        "subtitle": "Symbool van het perfecte pact",
+        "meaning": [
+          "Belofte van een uitzonderlijke afspraak buiten sociale normen.",
+          "Verklaringen van totale loyaliteit in ruil voor controle."
+        ],
+        "when": [
+          "Wanneer de narcist een geheime samenwerking of 'speciale' deal aanbiedt.",
+          "Tijdens plotselinge cadeaus na conflicten.",
+          "Vlak voordat om een riskant loyaliteitsgebaar wordt gevraagd."
+        ],
+        "action": [
+          "Vraag naar concrete gevolgen en neem bedenktijd.",
+          "Bespreek het aanbod met een vertrouweling voordat je toestemt."
+        ]
+      },
+      "4": {
+        "title": "Vier",
+        "subtitle": "Symbool van het gesloten netwerk",
+        "meaning": [
+          "Vier pijlers van afhankelijkheid: emotie, geld, reputatie, toegang tot geliefden.",
+          "Toont een systeem waarin elke keuze vier controlehendels heeft."
+        ],
+        "when": [
+          "Wanneer financiële steun gepaard gaat met volledige verantwoording.",
+          "Als de dader bepaalt wie jouw vrienden mogen zijn."
+        ],
+        "action": [
+          "Breng alternatieve steun in kaart buiten de dader om.",
+          "Splits afhankelijkheden: eigen budget, andere communicatieroutes.",
+          "Zeker vandaag nog één pijler veilig."
+        ]
+      },
+      "8": {
+        "title": "Acht",
+        "subtitle": "Symbool van de terugkeerlus",
+        "meaning": [
+          "Eindeloze belofte van verbetering.",
+          "Toont de cyclus: 'nooit meer' wordt 'weer opnieuw'.",
+          "Verwijst naar de verslavende dynamiek van uit elkaar gaan en terugkomen."
+        ],
+        "when": [
+          "Na een breuk wanneer direct therapie of verandering wordt beloofd.",
+          "Als de afspraken agenda op een sinusgolf lijkt.",
+          "Direct nadat het slachtoffer grenzen of ultimata stelt."
+        ],
+        "action": [
+          "Noteer voorwaarden voor terugkeer en plan een evaluatiemoment.",
+          "Volg echte verandering, niet alleen woorden."
+        ]
+      },
+      "13": {
+        "title": "Dertien",
+        "subtitle": "Symbool van breuk en alarm",
+        "meaning": [
+          "Aankondiging van een drastische breuk als dreigement.",
+          "Kan wijzen op escalatie naar economisch of juridisch geweld."
+        ],
+        "when": [
+          "Wanneer wordt gedreigd met het afpakken van kinderen of bezit.",
+          "Als het slachtoffer vertrek of bewijsdeling voorbereidt.",
+          "Vlak voor grote gebeurtenissen: feestdagen, contract, verhuizing."
+        ],
+        "action": [
+          "Beveilig documenten en noodcontacten.",
+          "Informeer een vertrouwenspersoon over mogelijke escalatie.",
+          "Maak een veiligheidsplan en verken lokale hulpbronnen."
+        ]
+      }
+    }
+  }
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -10,29 +10,12 @@
     "lab": "Laboratorium",
     "community": "Społeczność"
   },
-  "pages": {
-    "home": {
-      "title": "Radio Adamowo",
-      "lead": "Nowa odsłona edukacyjnego radia o przemocy psychicznej."
-    },
-    "live": {
-      "title": "Transmisja na żywo"
-    },
-    "guides": {
-      "title": "Poradniki"
-    },
-    "lab": {
-      "title": "Laboratorium AI"
-    },
-    "community": {
-      "title": "Społeczność"
-    },
-    "violenceLoop": {
-      "title": "Pętla przemocy"
-    },
-    "shows": {
-      "title": "Audycje"
-    }
+  "header": {
+    "skipToContent": "Przejdź do treści głównej",
+    "openMenu": "Otwórz menu",
+    "closeMenu": "Zamknij menu",
+    "home": "Powrót do strony głównej Radio Adamowo",
+    "navigation": "Główna nawigacja"
   },
   "controls": {
     "theme": {
@@ -47,4 +30,342 @@
       "resolved_dark": "tryb ciemny",
       "resolved_light": "tryb jasny"
     },
+    "language": {
+      "label": "Zmiana języka",
+      "pl": "Polski",
+      "nl": "Niderlandzki",
+      "en": "Angielski"
+    }
+  },
+  "pages": {
+    "home": {
+      "title": "Radio Adamowo",
+      "lead": "Nowa odsłona edukacyjnego radia o przemocy psychicznej."
+    },
+    "live": {
+      "title": "Transmisja na żywo"
+    },
+    "guides": {
+      "title": "Poradniki",
+      "lede": "Centrum edukacyjne o manipulacji, narcyzmie i dokumentowaniu przemocy psychicznej.",
+      "anchorNav": "Nawigacja po sekcjach poradnika",
+      "links": {
+        "library": "Biblioteka przypadków",
+        "mythology": "Mitologia Narcyza"
+      }
+    },
+    "lab": {
+      "title": "Laboratorium AI"
+    },
+    "community": {
+      "title": "Społeczność"
+    },
+    "violenceLoop": {
+      "title": "Pętla przemocy"
+    },
+    "shows": {
+      "title": "Audycje"
+    }
+  },
+  "player": {
+    "regionLabel": "Odtwarzacz stacji Radio Adamowo",
+    "artworkAlt": "Okładka audycji {{title}} — {{artist}}",
+    "live": "Na żywo",
+    "buffering": "Buforowanie sygnału…",
+    "reconnecting": "Próba ponownego połączenia (pozostało {{seconds}} s)",
+    "error": "Nie udało się odtworzyć strumienia.",
+    "idle": "Odtwarzacz gotowy",
+    "nowPlaying": "Teraz gramy",
+    "visualizerAria": "Wizualizacja fal dźwiękowych",
+    "play": "Odtwórz",
+    "pause": "Wstrzymaj",
+    "mute": "Wycisz",
+    "unmute": "Przywróć dźwięk",
+    "quality_128kbps": "128 kbps",
+    "volume": "Głośność",
+    "retry": "Spróbuj ponownie"
+  },
+  "whisper": {
+    "regionLabel": "Szept zza Kurtyny — rekonstrukcja przesłuchania",
+    "length": "Czas nagrania",
+    "title": "Szept zza Kurtyny",
+    "subtitle": "Nagranie dokumentuje napięte przesłuchanie publiczne z 2017 roku.",
+    "ethics": {
+      "title": "Zasady etyczne słuchacza",
+      "body": [
+        "Słuchaj z empatią — każde westchnienie to realna osoba.",
+        "Zwracaj uwagę na pauzy i niedopowiedzenia, w nich ukryta jest dynamika władzy.",
+        "Notuj fakty, unikaj osądów — materiał służy edukacji i profilaktyce."
+      ]
+    },
+    "play": "Odtwórz",
+    "pause": "Wstrzymaj",
+    "restart": "Zacznij od początku",
+    "mute": "Wycisz",
+    "unmute": "Włącz dźwięk",
+    "scrub": "Linia czasu",
+    "volume": "Głośność",
+    "status": {
+      "paused": "Nagranie wstrzymane.",
+      "playing": "Odtwarzanie aktywne.",
+      "ended": "Nagranie zakończone.",
+      "error": "Nie można odtworzyć pliku audio.",
+      "restarted": "Nagranie uruchomione od początku.",
+      "seeked": "Przesunięto pozycję odtwarzania.",
+      "muted": "Dźwięk został wyciszony.",
+      "unmuted": "Dźwięk został przywrócony.",
+      "volume": "Głośność ustawiona na {{value}}%"
+    }
+  },
+  "library": {
+    "kicker": "Biblioteka przypadków",
+    "title": "Biblioteka Przypadków",
+    "intro": "Cztery narzędzia do rozpoznawania przemocy narcyzmu: studium przypadku, analiza kalendarza, arsenał taktyk i metody dokumentacji.",
+    "gridLabel": "Lista kart biblioteki",
+    "view": "Zobacz",
+    "details": "Panel wiedzy",
+    "tabs": {
+      "label": "Zakładki treści biblioteki",
+      "summary": "Streszczenie",
+      "timeline": "Oś czasu",
+      "resources": "Materiały",
+      "tips": "Wskazówki"
+    },
+    "empty": {
+      "timeline": "Brak zarejestrowanych wydarzeń w osi czasu.",
+      "resources": "Materiały będą dostępne wkrótce.",
+      "tips": "Brak dodatkowych wskazówek dla tego przypadku."
+    },
+    "tags": {
+      "label": "Tagi przypadku",
+      "caseStudy": "case study",
+      "escalation": "eskalacja",
+      "family": "relacje rodzinne",
+      "timeline": "oś czasu",
+      "data": "analiza danych",
+      "patterns": "wzorce",
+      "tactics": "taktyki",
+      "narcissism": "narcyzm",
+      "relationships": "relacje",
+      "documentation": "dokumentacja",
+      "procedures": "procedury",
+      "community": "wsparcie"
+    },
+    "entries": {
+      "caseAdamscy": {
+        "title": "Sprawa Adamskich: Wprowadzenie",
+        "summary": "Rodzina Adamskich zgłosiła serię subtelnych, lecz narastających aktów izolacji i dewaluacji ze strony głowy rodziny.",
+        "content": [
+          "Analiza rozpoczyna się od codziennych obserwacji: zamykane drzwi, przejmowanie rozmów i narastająca kontrola nad codziennym grafikiem rodziny.",
+          "Pojawiają się próby rozbijania więzi — prezenty dla wybranych członków, krytyka reszty i straszenie odebraniem środków finansowych.",
+          "Moment przełomowy następuje, gdy najmłodsza córka dokumentuje komentarze, a sąsiedzi potwierdzają zmianę zachowania sprawcy."
+        ],
+        "tips": [
+          "Zbieraj zapiski z codziennych interakcji, nawet jeśli wydają się banalne.",
+          "Porównuj relacje różnych członków rodziny — narcyz często dzieli otoczenie na frakcje.",
+          "Sprawdzaj, czy pojawiają się nagłe gesty dobroci poprzedzone epizodami upokorzeń."
+        ],
+        "timeline": [
+          {
+            "when": "Styczeń 2020",
+            "title": "Pierwsze sygnały izolacji",
+            "note": "Sprawca przejmuje planowanie czasu dzieci i ogranicza ich kontakty online."
+          },
+          {
+            "when": "Marzec 2020",
+            "title": "Wzmożona kontrola finansowa",
+            "note": "Dochodzi do wymuszania paragonów i kar za wydatki spoza listy."
+          },
+          {
+            "when": "Czerwiec 2020",
+            "title": "Zebranie dowodów i interwencja"
+          }
+        ],
+        "resources": [
+          "Raport obserwacyjny rodziny Adamskich",
+          "Lista kontrolna sygnałów izolacji"
+        ]
+      },
+      "calendarAnalysis": {
+        "title": "Analiza Kalendarza: Kronika Eskalacji",
+        "summary": "Technika rejestrowania mikro-zdarzeń, które tworzą pełny obraz cyklu przemocy psychicznej.",
+        "content": [
+          "Metoda opiera się na codziennym zapisywaniu zdarzeń w kalendarzu i oznaczaniu ich kolorami według typu nadużycia.",
+          "Po 30 dniach powstaje mapa częstotliwości, która ujawnia fazy idealizacji, dewaluacji i ciszy.",
+          "Zestawienie z kalendarzem ofiary i sprawcy pozwala dostrzec korelacje między obietnicami a karami."
+        ],
+        "tips": [
+          "Ustal jedno miejsce zapisu, by uniknąć chaosu w danych.",
+          "Dodawaj krótkie cytaty lub opis tonu głosu — to ważne w analizie.",
+          "Raz w tygodniu omawiaj wpisy z osobą zaufaną lub terapeutą."
+        ],
+        "timeline": [
+          {
+            "when": "Dzień 1",
+            "title": "Start obserwacji",
+            "note": "Ustalono legendę kolorów i kategorię 'alarm'."
+          },
+          {
+            "when": "Dzień 14",
+            "title": "Pierwsze wzory",
+            "note": "Powtarza się cykl: prezent – milczenie – krytyka."
+          },
+          {
+            "when": "Dzień 30",
+            "title": "Raport i omówienie"
+          }
+        ],
+        "resources": [
+          "Szablon kalendarza eskalacji"
+        ]
+      },
+      "princeIngratitude": {
+        "title": "\u201eKsiążę Niewdzięczność\u201d: Broń Narcyza",
+        "summary": "Strategia nagłego odebrania łaski po okresie idealizacji, by wymusić całkowite podporządkowanie.",
+        "content": [
+          "Narcyz konstruuje scenariusz baśniowy: obietnice awansu, wspólnych projektów lub statusu. Ofiara otrzymuje 'tytuł księcia'.",
+          "Gdy zaufanie jest pełne, następuje ciche wycofanie wsparcia i publiczne zawstydzenie ofiary.",
+          "Mechanizm działa, bo ofiara broni wyimaginowanego statusu, a nie realnej relacji."
+        ],
+        "tips": [
+          "Sprawdzaj, czy oferowane przywileje mają konkretne podstawy prawne lub finansowe.",
+          "Zwracaj uwagę na momenty, gdy narcyz żąda wdzięczności bez faktycznej pomocy.",
+          "Ustal własne kryteria sukcesu zamiast przyjmować narrację sprawcy."
+        ],
+        "timeline": [
+          {
+            "when": "Tydzień 1",
+            "title": "Idealizacja i tytułowanie"
+          },
+          {
+            "when": "Tydzień 4",
+            "title": "Publiczne odebranie łaski",
+            "note": "Ofiara zostaje ośmieszona przy świadkach."
+          }
+        ],
+        "resources": [
+          "Ćwiczenie refleksyjne: rozpoznaj narrację narcyza"
+        ]
+      },
+      "investigationDocs": {
+        "title": "Śledztwo: Jak Dokumentować Manipulacje?",
+        "summary": "Procedura zbierania dowodów bez eskalowania konfliktu oraz z poszanowaniem bezpieczeństwa ofiary.",
+        "content": [
+          "Twórz dziennik zdarzeń z datami, godzinami i źródłami: wiadomości SMS, e-maile, nagrania głosu.",
+          "Ustal protokół przechowywania plików w zaszyfrowanej chmurze lub na nośniku offline.",
+          "Dołącz świadectwa osób trzecich oraz dokumenty instytucji (szkoła, lekarz, pracodawca)."
+        ],
+        "tips": [
+          "Używaj identycznych nazw plików: data_miejsce_zdarzenie.",
+          "Nie informuj sprawcy o dokumentowaniu, jeśli grozi to retorsją.",
+          "Współpracuj z lokalnymi grupami wsparcia, by zapewnić sobie zaplecze prawne."
+        ],
+        "timeline": [
+          {
+            "when": "Tydzień 1",
+            "title": "Założenie dziennika zdarzeń"
+          },
+          {
+            "when": "Tydzień 3",
+            "title": "Konfrontacja z dowodami",
+            "note": "Materiały przekazane mediatorowi."
+          },
+          {
+            "when": "Tydzień 6",
+            "title": "Przygotowanie raportu dla instytucji"
+          }
+        ],
+        "resources": [
+          "Arkusz ewidencji dowodów",
+          "Przewodnik do rozmów świadków"
+        ]
+      }
+    }
+  },
+  "mythology": {
+    "kicker": "Mitologia narcyza",
+    "title": "Mitologia Narcyza",
+    "intro": "Cztery symbole ostrzegawcze opisujące cykl kontroli: 7 — pakt idealizacji, 4 — sieć zależności, 8 — pętla powrotów, 13 — alarm rozstania.",
+    "gridLabel": "Symbole mitologii narcyza",
+    "viewSymbol": "Zobacz symbol",
+    "symbolCode": "Symbol {{code}}",
+    "detailKicker": "Rozszyfrowanie symbolu",
+    "blocks": {
+      "meaning": "Co oznacza",
+      "when": "Kiedy się pojawia",
+      "actions": "Jak reagować"
+    },
+    "symbol": {
+      "7": {
+        "title": "Siedem",
+        "subtitle": "Symbol idealnego paktu",
+        "meaning": [
+          "Obietnica wyjątkowego porozumienia ponad normami społecznymi.",
+          "Deklaracje totalnej lojalności w zamian za oddanie sterów."
+        ],
+        "when": [
+          "Gdy narcyz proponuje tajną współpracę lub 'specjalny' układ.",
+          "W momentach nagłych prezentów po okresie konfliktów.",
+          "Tuż przed prośbą o ryzykowny gest lojalności."
+        ],
+        "action": [
+          "Pytaj o realne konsekwencje umowy i proś o czas do namysłu.",
+          "Rozmawiaj z osobą zaufaną, zanim przystaniesz na warunki."
+        ]
+      },
+      "4": {
+        "title": "Cztery",
+        "subtitle": "Symbol zamkniętej sieci",
+        "meaning": [
+          "Cztery filary zależności: emocje, pieniądze, reputacja, dostęp do bliskich.",
+          "Wskazuje na układ, w którym każda decyzja ma cztery wersje kontroli."
+        ],
+        "when": [
+          "Gdy wsparcie finansowe wiąże się z raportowaniem każdej wydanej złotówki.",
+          "Kiedy narcyz narzuca, kto może być twoim przyjacielem."
+        ],
+        "action": [
+          "Zmapuj, od kogo poza sprawcą możesz otrzymać wsparcie.",
+          "Podziel zależności: osobny budżet, alternatywne kanały komunikacji.",
+          "Sprawdź, które z czterech filarów możesz zabezpieczyć już dziś."
+        ]
+      },
+      "8": {
+        "title": "Osiem",
+        "subtitle": "Symbol pętli powrotów",
+        "meaning": [
+          "Pętla nieskończonych obietnic poprawy.",
+          "Wskazuje na cykliczność: 'już nigdy' zamienia się w 'znowu to samo'.",
+          "Odnosi się do uzależniającej dynamiki rozstań i powrotów."
+        ],
+        "when": [
+          "Gdy po zerwaniu narcyz natychmiast obiecuje terapię lub zmianę pracy.",
+          "Kiedy harmonogram spotkań zaczyna przypominać sinusoidę.",
+          "Tuż po tym, jak ofiara zapowiada granice lub ultimatum."
+        ],
+        "action": [
+          "Spisz warunki powrotu i ustal datę przeglądu postępów.",
+          "Monitoruj faktyczne zmiany, nie deklaracje."
+        ]
+      },
+      "13": {
+        "title": "Trzynaście",
+        "subtitle": "Symbol przerwania i alarmu",
+        "meaning": [
+          "Zapowiedź radykalnego cięcia — często używanego jako straszak.",
+          "Może oznaczać eskalację w stronę przemocy ekonomicznej lub prawnej."
+        ],
+        "when": [
+          "Gdy narcyz straszy odebraniem dzieci lub majątku.",
+          "W momentach, gdy ofiara planuje ucieczkę lub ujawnienie dowodów.",
+          "Tuż przed dużymi wydarzeniami: święta, podpisanie umowy, przeprowadzka."
+        ],
+        "action": [
+          "Zabezpiecz dokumenty i kontakty awaryjne.",
+          "Powiadom zaufaną osobę o możliwej eskalacji.",
+          "Przygotuj plan bezpieczeństwa i sprawdź lokalne zasoby pomocy."
+        ]
+      }
+    }
+  }
 }

--- a/src/pages/Guides.tsx
+++ b/src/pages/Guides.tsx
@@ -1,14 +1,45 @@
 import { useTranslation } from 'react-i18next';
 
+import { LibrarySection } from '../features/library/LibrarySection';
+import { MythologySection } from '../features/mythology/MythologySection';
+
 export default function Guides(): JSX.Element {
   const { t } = useTranslation();
 
   return (
-    <section>
-      <h1 className="text-3xl font-bold text-base-50 sm:text-4xl">{t('pages.guides.title')}</h1>
-      <p className="mt-4 max-w-2xl text-base-200">
-        Guidance and educational modules will appear here.
-      </p>
+    <section className="space-y-12">
+      <header className="space-y-6">
+        <div className="space-y-4">
+          <h1 className="font-display text-4xl font-semibold text-base-50 sm:text-5xl">
+            {t('pages.guides.title')}
+          </h1>
+          <p className="max-w-3xl text-base text-base-200">{t('pages.guides.lede')}</p>
+        </div>
+        <nav
+          aria-label={t('pages.guides.anchorNav')}
+          className="flex flex-wrap gap-3"
+        >
+          <a
+            href="#library"
+            className="inline-flex items-center gap-2 rounded-full border border-accent-500/50 bg-base-925/60 px-4 py-2 text-sm font-semibold text-accent-100 transition motion-safe:hover:border-accent-400 motion-safe:hover:text-accent-50 focus-visible:shadow-focus"
+          >
+            <span aria-hidden="true">📚</span>
+            <span>{t('pages.guides.links.library')}</span>
+          </a>
+          <a
+            href="#mythology"
+            className="inline-flex items-center gap-2 rounded-full border border-accent-500/50 bg-base-925/60 px-4 py-2 text-sm font-semibold text-accent-100 transition motion-safe:hover:border-accent-400 motion-safe:hover:text-accent-50 focus-visible:shadow-focus"
+          >
+            <span aria-hidden="true">✨</span>
+            <span>{t('pages.guides.links.mythology')}</span>
+          </a>
+        </nav>
+      </header>
+
+      <div className="space-y-12">
+        <LibrarySection sectionId="library" />
+        <MythologySection sectionId="mythology" />
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add the case library feature with cards, tabbed details and supporting data sources
- introduce the narcissist mythology module with custom SVG icons and actionable guidance
- wire the new sections into the guides page, extend translations in PL/NL/EN and document the content model

## Testing
- `pnpm lint` *(fails: registry access is blocked in the execution environment)*
- `npx vitest run` *(fails: the environment cannot install the required jsdom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68db1a6e8b648322a5df634653b98640