### PR TITLE
feat: add analysis archive section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,15 @@ Aplikacja uruchomi się pod adresem `http://localhost:5173`.
 
 ## Testy
 Testy jednostkowe znajdują się w katalogu obok komponentów lub w `src/test`.
+
+## Audycje Analityczne
+- Kontener funkcjonalności znajduje się w `src/features/analysis-archive`.
+- Dane lokalne i schemat typów są w plikach `data.local.json` oraz `data.schema.ts`.
+- Domyślnie aplikacja korzysta z mocka JSON; aby włączyć Supabase ustaw zmienne środowiskowe:
+
+```bash
+VITE_SUPABASE_URL="https://<projekt>.supabase.co"
+VITE_SUPABASE_ANON="<anon-key>"
+```
+
+- API pobiera dane z tabeli `episodes` i wspiera filtrowanie po tytule/opisie, kategoriach, tagach i sortowaniu.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.48.1",
     "clsx": "^2.1.1",
     "i18next": "^23.11.5",
     "i18next-browser-languagedetector": "^7.2.0",

--- a/src/features/analysis-archive/AnalysisPage.tsx
+++ b/src/features/analysis-archive/AnalysisPage.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { AnalysisPlayer, type AnalysisPlayerHandle } from './AnalysisPlayer';
+import { EpisodeDetails } from './EpisodeDetails';
+import { EpisodeList } from './EpisodeList';
+import { FiltersBar } from './FiltersBar';
+import type { Episode, EpisodeCategory, EpisodeFiltersMetadata, EpisodeSort } from './data.schema';
+import { getEpisodes } from './api';
+
+const ALL_CATEGORIES: EpisodeCategory[] = [
+  'AktDarowania',
+  'SłużebnośćUwiązania',
+  'SprawaAdamskich',
+  'BronNarcyza',
+  'Sledztwo'
+];
+
+type FiltersState = {
+  search: string;
+  categories: EpisodeCategory[];
+  tags: string[];
+  sort: EpisodeSort;
+  page: number;
+  pageSize: number;
+};
+
+const INITIAL_FILTERS: FiltersState = {
+  search: '',
+  categories: [],
+  tags: [],
+  sort: 'newest',
+  page: 1,
+  pageSize: 6
+};
+
+function mergeMetadata(metadata: EpisodeFiltersMetadata): EpisodeFiltersMetadata {
+  const categoryMap = new Map(metadata.categories.map((item) => [item.value, item.count] as const));
+
+  for (const category of ALL_CATEGORIES) {
+    if (!categoryMap.has(category)) {
+      categoryMap.set(category, 0);
+    }
+  }
+
+  return {
+    categories: Array.from(categoryMap.entries()).map(([value, count]) => ({ value, count })),
+    tags: metadata.tags
+  };
+}
+
+export default function AnalysisPage(): JSX.Element {
+  const { t } = useTranslation();
+  const [filters, setFilters] = useState<FiltersState>(INITIAL_FILTERS);
+  const [episodes, setEpisodes] = useState<Episode[]>([]);
+  const [total, setTotal] = useState(0);
+  const [metadata, setMetadata] = useState<EpisodeFiltersMetadata>({ categories: [], tags: [] });
+  const [isLoading, setIsLoading] = useState(true);
+  const playerRef = useRef<AnalysisPlayerHandle | null>(null);
+  const [selectedEpisode, setSelectedEpisode] = useState<Episode | null>(null);
+  const selectedIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    selectedIdRef.current = selectedEpisode?.id ?? null;
+  }, [selectedEpisode]);
+
+  useEffect(() => {
+    let isActive = true;
+    setIsLoading(true);
+
+    const controller = new AbortController();
+
+    const loadData = async () => {
+      try {
+        const result = await getEpisodes({
+          q: filters.search,
+          categories: filters.categories,
+          tags: filters.tags,
+          sort: filters.sort,
+          page: filters.page,
+          pageSize: filters.pageSize
+        });
+
+        if (!isActive) {
+          return;
+        }
+
+        setEpisodes(result.episodes);
+        setTotal(result.total);
+        setMetadata(mergeMetadata(result.metadata));
+
+        const currentSelectedId = selectedIdRef.current;
+        const nextSelected =
+          (currentSelectedId && result.episodes.find((episode) => episode.id === currentSelectedId)) ??
+          result.episodes[0] ??
+          null;
+        setSelectedEpisode(nextSelected);
+      } catch (error) {
+        if ((error as Error).name !== 'AbortError') {
+          console.error('[analysis-page] Failed to load episodes', error);
+        }
+      } finally {
+        if (isActive) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadData();
+
+    return () => {
+      isActive = false;
+      controller.abort();
+    };
+  }, [filters]);
+
+  const pageCount = useMemo(() => {
+    if (filters.pageSize === 0) {
+      return 1;
+    }
+
+    return Math.max(1, Math.ceil(total / filters.pageSize));
+  }, [total, filters.pageSize]);
+
+  const handleSelectEpisode = (episode: Episode) => {
+    setSelectedEpisode(episode);
+  };
+
+  const handleSelectChapter = (seconds: number) => {
+    playerRef.current?.seekTo(seconds);
+  };
+
+  const handleSearchChange = (value: string) => {
+    setFilters((prev) => ({ ...prev, search: value, page: 1 }));
+  };
+
+  const handleToggleCategory = (value: EpisodeCategory) => {
+    setFilters((prev) => {
+      const nextCategories = prev.categories.includes(value)
+        ? prev.categories.filter((category) => category !== value)
+        : [...prev.categories, value];
+      return { ...prev, categories: nextCategories, page: 1 };
+    });
+  };
+
+  const handleToggleTag = (value: string) => {
+    setFilters((prev) => {
+      const nextTags = prev.tags.includes(value)
+        ? prev.tags.filter((tag) => tag !== value)
+        : [...prev.tags, value];
+      return { ...prev, tags: nextTags, page: 1 };
+    });
+  };
+
+  const handleSortChange = (value: EpisodeSort) => {
+    setFilters((prev) => ({ ...prev, sort: value, page: 1 }));
+  };
+
+  const handlePageChange = (delta: number) => {
+    setFilters((prev) => {
+      const nextPage = Math.min(Math.max(prev.page + delta, 1), pageCount);
+      return { ...prev, page: nextPage };
+    });
+  };
+
+  return (
+    <section className="space-y-6" aria-labelledby="analysis-archive-title" role="region">
+      <header className="rounded-2xl border border-base-800 bg-[linear-gradient(160deg,_#0f132a,_#050714)] p-8 text-base-50 shadow-xl shadow-black/40">
+        <h1 id="analysis-archive-title" className="text-3xl font-semibold text-accent-200">
+          {t('analysis.page.title')}
+        </h1>
+        <p className="mt-2 max-w-2xl text-base-300">{t('analysis.page.lead')}</p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[320px_1fr_360px]">
+        <FiltersBar
+          total={total}
+          search={filters.search}
+          categories={filters.categories}
+          tags={filters.tags}
+          sort={filters.sort}
+          metadata={metadata}
+          onSearchChange={handleSearchChange}
+          onToggleCategory={handleToggleCategory}
+          onToggleTag={handleToggleTag}
+          onSortChange={handleSortChange}
+        />
+
+        <div className="space-y-4">
+          <EpisodeList
+            episodes={episodes}
+            selectedEpisodeId={selectedEpisode?.id ?? null}
+            onSelect={handleSelectEpisode}
+            isLoading={isLoading}
+          />
+
+          <div className="flex items-center justify-between rounded-full border border-base-800 bg-base-900/50 px-4 py-2 text-sm text-base-200">
+            <span>{t('analysis.pagination.pageIndicator', { page: filters.page, pages: pageCount })}</span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => handlePageChange(-1)}
+                disabled={filters.page <= 1}
+                className="rounded-full border border-base-700 px-3 py-1 text-xs uppercase tracking-wide transition hover:border-accent-400 hover:text-accent-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 disabled:cursor-not-allowed disabled:border-base-800 disabled:text-base-600"
+              >
+                {t('analysis.pagination.previous')}
+              </button>
+              <button
+                type="button"
+                onClick={() => handlePageChange(1)}
+                disabled={filters.page >= pageCount}
+                className="rounded-full border border-base-700 px-3 py-1 text-xs uppercase tracking-wide transition hover:border-accent-400 hover:text-accent-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 disabled:cursor-not-allowed disabled:border-base-800 disabled:text-base-600"
+              >
+                {t('analysis.pagination.next')}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <AnalysisPlayer ref={playerRef} episode={selectedEpisode} />
+          <EpisodeDetails episode={selectedEpisode} onSelectChapter={handleSelectChapter} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/analysis-archive/AnalysisPlayer.tsx
+++ b/src/features/analysis-archive/AnalysisPlayer.tsx
@@ -1,0 +1,285 @@
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { Episode } from './data.schema';
+
+export type AnalysisPlayerHandle = {
+  seekTo: (seconds: number) => void;
+};
+
+type AnalysisPlayerProps = {
+  episode: Episode | null;
+};
+
+function formatTime(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds)) {
+    return '0:00';
+  }
+
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = Math.floor(totalSeconds % 60)
+    .toString()
+    .padStart(2, '0');
+
+  return `${minutes}:${seconds}`;
+}
+
+export const AnalysisPlayer = forwardRef<AnalysisPlayerHandle, AnalysisPlayerProps>(function AnalysisPlayer(
+  { episode },
+  ref
+) {
+  const { t } = useTranslation();
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const statusRef = useRef<HTMLSpanElement | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(episode?.durationSec ?? 0);
+  const [volume, setVolume] = useState(0.9);
+  const [isMuted, setIsMuted] = useState(false);
+
+  useImperativeHandle(ref, () => ({
+    seekTo(seconds: number) {
+      const audio = audioRef.current;
+      if (!audio) {
+        return;
+      }
+
+      audio.currentTime = Math.min(Math.max(seconds, 0), audio.duration || seconds);
+      setCurrentTime(audio.currentTime);
+    }
+  }));
+
+  useEffect(() => {
+    const audio = audioRef.current;
+
+    if (!audio) {
+      return;
+    }
+
+    const handleLoaded = () => {
+      const metaDuration = Number.isFinite(audio.duration) && audio.duration > 0 ? audio.duration : null;
+      setDuration(metaDuration ?? episode?.durationSec ?? 0);
+      setCurrentTime(0);
+      setIsPlaying(false);
+    };
+
+    const handleTime = () => {
+      setCurrentTime(audio.currentTime);
+    };
+
+    const handleEnded = () => {
+      setIsPlaying(false);
+    };
+
+    audio.addEventListener('loadedmetadata', handleLoaded);
+    audio.addEventListener('timeupdate', handleTime);
+    audio.addEventListener('ended', handleEnded);
+
+    return () => {
+      audio.removeEventListener('loadedmetadata', handleLoaded);
+      audio.removeEventListener('timeupdate', handleTime);
+      audio.removeEventListener('ended', handleEnded);
+    };
+  }, [episode?.id]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+
+    if (!audio) {
+      return;
+    }
+
+    audio.volume = isMuted ? 0 : volume;
+    audio.muted = isMuted;
+  }, [volume, isMuted]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+
+    if (!audio) {
+      return;
+    }
+
+    if (episode) {
+      audio.src = episode.audioUrl;
+      audio.load();
+      setCurrentTime(0);
+      setDuration(episode.durationSec ?? 0);
+      setIsPlaying(false);
+    } else {
+      audio.pause();
+      audio.removeAttribute('src');
+      setCurrentTime(0);
+      setDuration(0);
+      setIsPlaying(false);
+    }
+  }, [episode?.audioUrl, episode?.durationSec, episode?.id]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    const playPromise = async () => {
+      try {
+        if (isPlaying) {
+          await audio.play();
+          statusRef.current?.setAttribute('data-status', 'playing');
+        } else {
+          audio.pause();
+          statusRef.current?.setAttribute('data-status', 'paused');
+        }
+      } catch (error) {
+        console.warn('[analysis-player] Failed to toggle playback', error);
+      }
+    };
+
+    void playPromise();
+  }, [isPlaying]);
+
+  const chapterMarkers = useMemo(() => {
+    if (!episode?.chapters || duration === 0) {
+      return [];
+    }
+
+    return episode.chapters.map((chapter) => ({
+      ...chapter,
+      position: Math.min(100, Math.max(0, (chapter.startSec / duration) * 100))
+    }));
+  }, [episode?.chapters, duration]);
+
+  const handleSeek = (value: number) => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    audio.currentTime = value;
+    setCurrentTime(value);
+  };
+
+  const toggleMute = () => {
+    setIsMuted((prev) => !prev);
+  };
+
+  const togglePlay = () => {
+    if (!episode) {
+      return;
+    }
+
+    setIsPlaying((prev) => !prev);
+  };
+
+  return (
+    <section
+      className="rounded-2xl border border-base-700 bg-[radial-gradient(circle_at_top,_#1a1f3a,_#080b1e)] p-6 text-base-50 shadow-lg shadow-indigo-950/40"
+      role="region"
+      aria-labelledby="analysis-player-heading"
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h2 id="analysis-player-heading" className="text-xl font-semibold text-accent-300">
+              {t('analysis.player.title')}
+            </h2>
+            <p className="text-sm text-base-200" aria-live="polite" ref={statusRef}>
+              {episode ? t('analysis.player.nowPlaying', { title: episode.title }) : t('analysis.player.idle')}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={togglePlay}
+            disabled={!episode}
+            className="rounded-full border border-accent-400 px-5 py-2 text-sm font-semibold text-accent-200 transition hover:bg-accent-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 disabled:cursor-not-allowed disabled:border-base-600 disabled:text-base-400"
+            aria-pressed={isPlaying}
+          >
+            {isPlaying ? t('analysis.player.pause') : t('analysis.player.play')}
+          </button>
+        </div>
+
+        <div className="relative">
+          <label className="flex flex-col gap-2" htmlFor="analysis-progress">
+            <span className="sr-only">{t('analysis.player.progress')}</span>
+            <input
+              id="analysis-progress"
+              type="range"
+              min={0}
+              max={duration || 0}
+              step={1}
+              value={Number.isFinite(currentTime) ? currentTime : 0}
+              onChange={(event) => handleSeek(Number(event.target.value))}
+              className="w-full accent-accent-400"
+              aria-valuemin={0}
+              aria-valuemax={duration || 0}
+              aria-valuenow={Number.isFinite(currentTime) ? currentTime : 0}
+              aria-label={t('analysis.player.progress')}
+            />
+          </label>
+          <div className="pointer-events-none absolute inset-x-4 top-1/2 -translate-y-1/2">
+            {chapterMarkers.map((chapter) => (
+              <span
+                key={chapter.title}
+                className="absolute h-3 w-3 -translate-y-1/2 rounded-full border border-accent-400 bg-accent-500/60 shadow"
+                style={{ left: `${chapter.position}%` }}
+                aria-hidden="true"
+              />
+            ))}
+          </div>
+          <div className="mt-2 flex justify-between text-xs text-base-300">
+            <span>{formatTime(currentTime)}</span>
+            <span>{formatTime(duration)}</span>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={toggleMute}
+              className="rounded-md border border-base-700 px-3 py-1 text-xs uppercase tracking-wide text-base-200 transition hover:border-accent-400 hover:text-accent-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400"
+              aria-pressed={isMuted}
+              aria-label={isMuted ? t('analysis.player.unmute') : t('analysis.player.mute')}
+            >
+              {isMuted ? t('analysis.player.unmute') : t('analysis.player.mute')}
+            </button>
+            <label className="flex items-center gap-2 text-xs text-base-300" htmlFor="analysis-volume">
+              <span>{t('analysis.player.volume')}</span>
+              <input
+                id="analysis-volume"
+                type="range"
+                min={0}
+                max={1}
+                step={0.05}
+                value={isMuted ? 0 : volume}
+                onChange={(event) => setVolume(Number(event.target.value))}
+                className="accent-accent-400"
+                aria-valuemin={0}
+                aria-valuemax={1}
+                aria-valuenow={isMuted ? 0 : volume}
+                aria-label={t('analysis.player.volume')}
+              />
+            </label>
+          </div>
+          {episode?.chapters && episode.chapters.length > 0 ? (
+            <div className="flex items-center gap-2 text-xs text-base-200">
+              <span>{t('analysis.player.chapters')}</span>
+              <div className="flex gap-1">
+                {episode.chapters.map((chapter) => (
+                  <span
+                    key={chapter.title}
+                    className="inline-block rounded-full border border-accent-400 px-2 py-0.5 text-[10px] uppercase tracking-wide text-accent-200"
+                  >
+                    {formatTime(chapter.startSec)}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <audio ref={audioRef} className="hidden" aria-hidden="true" />
+    </section>
+  );
+});

--- a/src/features/analysis-archive/EpisodeCard.tsx
+++ b/src/features/analysis-archive/EpisodeCard.tsx
@@ -1,0 +1,76 @@
+import { useTranslation } from 'react-i18next';
+
+import type { Episode } from './data.schema';
+
+type EpisodeCardProps = {
+  episode: Episode;
+  isActive: boolean;
+  onSelect: (episode: Episode) => void;
+};
+
+function formatDuration(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const remainder = Math.floor(seconds % 60)
+    .toString()
+    .padStart(2, '0');
+
+  return `${minutes}:${remainder}`;
+}
+
+export function EpisodeCard({ episode, isActive, onSelect }: EpisodeCardProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <article
+      className="group relative overflow-hidden rounded-2xl border border-base-800 bg-base-950/60 p-6 shadow-lg shadow-black/30 transition hover:border-accent-400 hover:shadow-accent-500/30"
+      aria-labelledby={`episode-${episode.id}`}
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 id={`episode-${episode.id}`} className="text-lg font-semibold text-base-50 group-hover:text-accent-200">
+              {episode.title}
+            </h3>
+            <p className="mt-1 text-xs uppercase tracking-wide text-accent-300">
+              {t(`analysis.categories.${episode.category}`)}
+            </p>
+          </div>
+          <span className="rounded-full border border-base-700 px-2 py-1 text-xs text-base-200">
+            {formatDuration(episode.durationSec)}
+          </span>
+        </div>
+
+        <p className="text-sm text-base-300">{episode.description}</p>
+
+        <div className="flex flex-wrap gap-2 text-xs text-base-400">
+          {episode.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full border border-base-800 px-2 py-1 text-[11px] uppercase tracking-wide"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => onSelect(episode)}
+            className="rounded-full border border-accent-400 px-4 py-2 text-sm font-semibold text-accent-200 transition hover:bg-accent-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400"
+            aria-pressed={isActive}
+            aria-label={t('analysis.actions.listenEpisode', { title: episode.title })}
+          >
+            {t('analysis.actions.listen')}
+          </button>
+
+          {isActive ? (
+            <span className="text-xs text-accent-200" aria-live="polite">
+              {t('analysis.actions.currentlyPlaying')}
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/features/analysis-archive/EpisodeDetails.tsx
+++ b/src/features/analysis-archive/EpisodeDetails.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useRef, type KeyboardEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { Episode } from './data.schema';
+
+type EpisodeDetailsProps = {
+  episode: Episode | null;
+  onSelectChapter: (seconds: number) => void;
+};
+
+export function EpisodeDetails({ episode, onSelectChapter }: EpisodeDetailsProps): JSX.Element {
+  const { t } = useTranslation();
+  const buttonsRef = useRef<HTMLButtonElement[]>([]);
+
+  useEffect(() => {
+    buttonsRef.current = [];
+  }, [episode?.id]);
+
+  const publishedDate = useMemo(() => {
+    if (!episode?.publishedAt) {
+      return null;
+    }
+
+    const date = new Date(episode.publishedAt);
+    return date.toLocaleDateString();
+  }, [episode?.publishedAt]);
+
+  if (!episode) {
+    return (
+      <aside
+        role="region"
+        aria-labelledby="analysis-details-heading"
+        className="rounded-2xl border border-base-800 bg-base-900/40 p-6 text-base-200"
+      >
+        <h2 id="analysis-details-heading" className="text-lg font-semibold text-base-100">
+          {t('analysis.details.emptyTitle')}
+        </h2>
+        <p className="mt-2 text-sm">{t('analysis.details.emptyHint')}</p>
+      </aside>
+    );
+  }
+
+  const handleKeyNavigation = (index: number, event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') {
+      return;
+    }
+
+    event.preventDefault();
+    const offset = event.key === 'ArrowRight' ? 1 : -1;
+    const next = buttonsRef.current[index + offset];
+    next?.focus();
+  };
+
+  return (
+    <aside
+      role="region"
+      aria-labelledby="analysis-details-heading"
+      className="flex h-full flex-col gap-4 rounded-2xl border border-base-800 bg-[linear-gradient(160deg,_#111831,_#090c1f)] p-6 text-base-100 shadow-lg shadow-black/30"
+    >
+      <div>
+        <h2 id="analysis-details-heading" className="text-xl font-semibold text-accent-300">
+          {episode.title}
+        </h2>
+        <p className="mt-1 text-sm text-base-300">
+          {t('analysis.details.published', { date: publishedDate ?? t('analysis.details.unknownDate') })}
+        </p>
+      </div>
+
+      <p className="text-sm leading-relaxed text-base-100/90">{episode.description}</p>
+
+      {episode.chapters && episode.chapters.length > 0 ? (
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-accent-200">
+            {t('analysis.details.chapters')}
+          </h3>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {episode.chapters.map((chapter, index) => (
+              <button
+                key={chapter.title}
+                type="button"
+                ref={(element) => {
+                  if (element) {
+                    buttonsRef.current[index] = element;
+                  }
+                }}
+                onClick={() => onSelectChapter(chapter.startSec)}
+                onKeyDown={(event) => handleKeyNavigation(index, event)}
+                className="rounded-full border border-accent-400 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-accent-200 transition hover:bg-accent-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400"
+                aria-label={t('analysis.details.seekTo', { title: chapter.title })}
+              >
+                {chapter.title}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {episode.resources && episode.resources.length > 0 ? (
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-accent-200">
+            {t('analysis.details.resources')}
+          </h3>
+          <ul className="mt-2 space-y-2 text-sm text-accent-200">
+            {episode.resources.map((resource) => (
+              <li key={resource.url}>
+                <a
+                  className="underline decoration-accent-400/60 underline-offset-4 transition hover:text-accent-400"
+                  href={resource.url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {resource.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </aside>
+  );
+}

--- a/src/features/analysis-archive/EpisodeList.tsx
+++ b/src/features/analysis-archive/EpisodeList.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next';
+
+import type { Episode } from './data.schema';
+import { EpisodeCard } from './EpisodeCard';
+
+type EpisodeListProps = {
+  episodes: Episode[];
+  selectedEpisodeId: string | null;
+  onSelect: (episode: Episode) => void;
+  isLoading?: boolean;
+};
+
+export function EpisodeList({ episodes, selectedEpisodeId, onSelect, isLoading = false }: EpisodeListProps): JSX.Element {
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-2xl border border-base-800 bg-base-900/40 text-base-300">
+        {t('analysis.state.loading')}
+      </div>
+    );
+  }
+
+  if (episodes.length === 0) {
+    return (
+      <div
+        role="status"
+        className="flex h-full items-center justify-center rounded-2xl border border-base-800 bg-base-900/40 p-8 text-center text-base-200"
+      >
+        {t('analysis.state.empty')}
+      </div>
+    );
+  }
+
+  return (
+    <ul className="grid gap-4" aria-label={t('analysis.list.ariaLabel')}>
+      {episodes.map((episode) => (
+        <li key={episode.id}>
+          <EpisodeCard episode={episode} isActive={episode.id === selectedEpisodeId} onSelect={onSelect} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/analysis-archive/FiltersBar.tsx
+++ b/src/features/analysis-archive/FiltersBar.tsx
@@ -1,0 +1,155 @@
+import { ChangeEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { EpisodeCategory, EpisodeFiltersMetadata, EpisodeSort } from './data.schema';
+
+type FiltersBarProps = {
+  total: number;
+  search: string;
+  categories: EpisodeCategory[];
+  tags: string[];
+  sort: EpisodeSort;
+  metadata: EpisodeFiltersMetadata;
+  onSearchChange: (value: string) => void;
+  onToggleCategory: (value: EpisodeCategory) => void;
+  onToggleTag: (value: string) => void;
+  onSortChange: (value: EpisodeSort) => void;
+};
+
+function formatCategoryId(category: EpisodeCategory): string {
+  return `analysis-category-${category}`;
+}
+
+function formatTagId(tag: string): string {
+  return `analysis-tag-${tag}`;
+}
+
+export function FiltersBar({
+  total,
+  search,
+  categories,
+  tags,
+  sort,
+  metadata,
+  onSearchChange,
+  onToggleCategory,
+  onToggleTag,
+  onSortChange
+}: FiltersBarProps): JSX.Element {
+  const { t } = useTranslation();
+  const resultId = 'analysis-results-count';
+
+  const handleSearch = (event: ChangeEvent<HTMLInputElement>) => {
+    onSearchChange(event.target.value);
+  };
+
+  const handleSort = (event: ChangeEvent<HTMLSelectElement>) => {
+    onSortChange(event.target.value as EpisodeSort);
+  };
+
+  return (
+    <section
+      className="sticky top-4 z-10 space-y-6 rounded-2xl border border-base-800 bg-[linear-gradient(160deg,_#10142c,_#050713)] p-6 shadow-lg shadow-black/40"
+      role="region"
+      aria-labelledby="analysis-filters-title"
+    >
+      <div className="flex items-center justify-between gap-4">
+        <h2 id="analysis-filters-title" className="text-lg font-semibold text-accent-300">
+          {t('analysis.filters.title')}
+        </h2>
+        <p id={resultId} className="text-sm text-base-300">
+          {t('analysis.filters.results', { count: total })}
+        </p>
+      </div>
+
+      <div className="space-y-4" aria-describedby={resultId}>
+        <label className="flex flex-col gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-base-200">
+            {t('analysis.filters.searchLabel')}
+          </span>
+          <input
+            type="search"
+            value={search}
+            onChange={handleSearch}
+            placeholder={t('analysis.filters.searchPlaceholder') ?? ''}
+            className="rounded-xl border border-base-800 bg-base-900/40 px-4 py-2 text-sm text-base-100 placeholder:text-base-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400"
+          />
+        </label>
+
+        <fieldset className="space-y-2" aria-describedby={resultId}>
+          <legend className="text-xs font-semibold uppercase tracking-wide text-base-200">
+            {t('analysis.filters.categoriesLabel')}
+          </legend>
+          <div className="flex flex-wrap gap-2">
+            {metadata.categories.map((category) => {
+              const id = formatCategoryId(category.value);
+              const checked = categories.includes(category.value);
+              return (
+                <label
+                  key={category.value}
+                  htmlFor={id}
+                  className="flex cursor-pointer items-center gap-2 rounded-full border border-base-700 px-3 py-1 text-xs text-base-200 transition hover:border-accent-400 hover:text-accent-200"
+                >
+                  <input
+                    id={id}
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => onToggleCategory(category.value)}
+                    className="h-3 w-3 accent-accent-400"
+                  />
+                  <span>{t(`analysis.categories.${category.value}`)}</span>
+                  <span className="text-[10px] text-base-500">{category.count}</span>
+                </label>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        <fieldset className="space-y-2" aria-describedby={resultId}>
+          <legend className="text-xs font-semibold uppercase tracking-wide text-base-200">
+            {t('analysis.filters.tagsLabel')}
+          </legend>
+          <div className="flex flex-wrap gap-2">
+            {metadata.tags.map((tag) => {
+              const id = formatTagId(tag.value);
+              const checked = tags.includes(tag.value);
+              return (
+                <label
+                  key={tag.value}
+                  htmlFor={id}
+                  className="flex cursor-pointer items-center gap-2 rounded-full border border-base-700 px-3 py-1 text-xs text-base-200 transition hover:border-accent-400 hover:text-accent-200"
+                >
+                  <input
+                    id={id}
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => onToggleTag(tag.value)}
+                    className="h-3 w-3 accent-accent-400"
+                  />
+                  <span>#{tag.value}</span>
+                  <span className="text-[10px] text-base-500">{tag.count}</span>
+                </label>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-base-200">
+            {t('analysis.filters.sortLabel')}
+          </span>
+          <select
+            value={sort}
+            onChange={handleSort}
+            className="rounded-xl border border-base-800 bg-base-900/40 px-3 py-2 text-sm text-base-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400"
+          >
+            <option value="newest">{t('analysis.filters.sortNewest')}</option>
+            <option value="oldest">{t('analysis.filters.sortOldest')}</option>
+            <option value="durationAsc">{t('analysis.filters.sortDurationAsc')}</option>
+            <option value="durationDesc">{t('analysis.filters.sortDurationDesc')}</option>
+          </select>
+        </label>
+      </div>
+    </section>
+  );
+}

--- a/src/features/analysis-archive/__tests__/AnalysisPage.test.tsx
+++ b/src/features/analysis-archive/__tests__/AnalysisPage.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import i18n from '../../../i18n';
+import AnalysisPage from '../AnalysisPage';
+import { getEpisodes } from '../api';
+
+async function renderAnalysis(): Promise<void> {
+  await i18n.changeLanguage('pl');
+  render(
+    <I18nextProvider i18n={i18n}>
+      <AnalysisPage />
+    </I18nextProvider>
+  );
+}
+
+describe('AnalysisPage', () => {
+  beforeAll(() => {
+    vi.spyOn(window.HTMLMediaElement.prototype, 'play').mockImplementation(() => Promise.resolve());
+    vi.spyOn(window.HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+  });
+
+  beforeEach(async () => {
+    await i18n.changeLanguage('pl');
+  });
+
+  it('filters episodes by search, category, tag and sort order', async () => {
+    await renderAnalysis();
+
+    await screen.findByText('Broń Narcyza: architektura kłamstwa');
+
+    const searchInput = screen.getByLabelText('Szukaj odcinka');
+    fireEvent.change(searchInput, { target: { value: 'cyfrowe' } });
+
+    await screen.findByText('Broń Narcyza: cyfrowe tropy');
+    await waitFor(() => expect(screen.queryByText('Broń Narcyza: architektura kłamstwa')).toBeNull());
+
+    fireEvent.change(searchInput, { target: { value: '' } });
+    await screen.findByText('Broń Narcyza: architektura kłamstwa');
+
+    const sledztwoCheckbox = screen.getByLabelText(/Śledztwo/);
+    fireEvent.click(sledztwoCheckbox);
+    await screen.findByText('Śledztwo: analiza sygnałów');
+    await waitFor(() => expect(screen.queryByText('Broń Narcyza: architektura kłamstwa')).toBeNull());
+
+    const terenTag = screen.getByLabelText(/#teren/);
+    fireEvent.click(terenTag);
+    await screen.findByText('Śledztwo: notatki terenowe');
+
+    fireEvent.click(terenTag);
+    fireEvent.click(sledztwoCheckbox);
+
+    const sortSelect = screen.getByLabelText('Sortowanie');
+    fireEvent.change(sortSelect, { target: { value: 'oldest' } });
+
+    await screen.findByText('Akt Darowania: początki narracji');
+    const cards = screen.getAllByRole('article');
+    expect(cards[0]).toHaveTextContent('Akt Darowania: początki narracji');
+  });
+
+  it('updates player when selecting a different episode', async () => {
+    await renderAnalysis();
+
+    await screen.findByText('Broń Narcyza: architektura kłamstwa');
+    const status = screen.getByText(/Odtwarzane:/);
+    expect(status).toHaveTextContent('Broń Narcyza: architektura kłamstwa');
+
+    const listenButton = screen.getByRole('button', {
+      name: /Słuchaj: Śledztwo: analiza sygnałów/i
+    });
+    fireEvent.click(listenButton);
+
+    await waitFor(() => {
+      expect(status).toHaveTextContent('Śledztwo: analiza sygnałów');
+    });
+  });
+
+  it('jumps to the requested chapter position', async () => {
+    await renderAnalysis();
+
+    await screen.findByText('Broń Narcyza: architektura kłamstwa');
+
+    const chapterButton = screen.getByRole('button', {
+      name: 'Przeskocz do rozdziału Reakcje społeczności'
+    });
+    fireEvent.click(chapterButton);
+
+    const progress = screen.getByLabelText('Postęp odtwarzania') as HTMLInputElement;
+    await waitFor(() => {
+      expect(progress.value).toBe('880');
+    });
+  });
+});
+
+describe('analysis data client', () => {
+  it('falls back to local JSON when Supabase env is missing', async () => {
+    vi.stubEnv('VITE_SUPABASE_URL', '');
+    vi.stubEnv('VITE_SUPABASE_ANON', '');
+
+    const result = await getEpisodes({ pageSize: 20 });
+
+    expect(result.total).toBeGreaterThan(0);
+    expect(result.metadata.categories.length).toBeGreaterThan(0);
+
+    vi.unstubAllEnvs();
+  });
+});

--- a/src/features/analysis-archive/api.ts
+++ b/src/features/analysis-archive/api.ts
@@ -1,0 +1,289 @@
+import localEpisodes from './data.local.json';
+import type {
+  Episode,
+  EpisodeCategory,
+  EpisodeFiltersMetadata,
+  EpisodeQuery,
+  EpisodeQueryResult,
+  EpisodeSort
+} from './data.schema';
+
+const LOCAL_EPISODES: Episode[] = (localEpisodes as Episode[]).map((episode) => ({
+  ...episode,
+  tags: episode.tags ?? []
+}));
+
+type SupabaseQueryResult = {
+  data: unknown;
+  error: unknown;
+  count: number | null;
+};
+
+type SupabaseQueryBuilder = {
+  select: (...args: unknown[]) => SupabaseQueryBuilderPromise;
+  in: (...args: unknown[]) => SupabaseQueryBuilder;
+  contains: (...args: unknown[]) => SupabaseQueryBuilder;
+  order: (...args: unknown[]) => SupabaseQueryBuilder;
+  range: (...args: unknown[]) => SupabaseQueryBuilder;
+};
+
+type SupabaseQueryBuilderPromise = SupabaseQueryBuilder & PromiseLike<SupabaseQueryResult>;
+
+type SupabaseClient = {
+  from: (table: string) => SupabaseQueryBuilder;
+};
+
+type CreateClientFn = (url: string, key: string, options?: Record<string, unknown>) => SupabaseClient;
+
+function getSupabaseConfig(): { url: string; key: string } | null {
+  const url = import.meta.env.VITE_SUPABASE_URL;
+  const key = import.meta.env.VITE_SUPABASE_ANON;
+
+  if (typeof url === 'string' && url.length > 0 && typeof key === 'string' && key.length > 0) {
+    return { url, key };
+  }
+
+  return null;
+}
+
+let cachedClient: SupabaseClient | null = null;
+let createClientFactory: CreateClientFn | null = null;
+let supabaseAttempted = false;
+
+async function getSupabaseClient(): Promise<SupabaseClient | null> {
+  const config = getSupabaseConfig();
+
+  if (!config) {
+    cachedClient = null;
+    return null;
+  }
+
+  if (cachedClient) {
+    return cachedClient;
+  }
+
+  if (!createClientFactory && !supabaseAttempted) {
+    supabaseAttempted = true;
+    try {
+      const module = await import('@supabase/supabase-js');
+      createClientFactory = (module as { createClient: CreateClientFn }).createClient;
+    } catch (error) {
+      console.warn('[analysis-archive] Supabase client not available, using local data.', error);
+      return null;
+    }
+  }
+
+  if (!createClientFactory) {
+    return null;
+  }
+
+  cachedClient = createClientFactory(config.url, config.key, {
+    auth: { persistSession: false }
+  });
+
+  return cachedClient;
+}
+
+function normalize(value: string): string {
+  return value.normalize('NFKD').toLowerCase();
+}
+
+function matchesQuery(episode: Episode, query: string): boolean {
+  const normalizedQuery = normalize(query);
+  const title = normalize(episode.title);
+  const description = normalize(episode.description);
+
+  return title.includes(normalizedQuery) || description.includes(normalizedQuery);
+}
+
+function filterByCategories(episode: Episode, categories?: EpisodeCategory[]): boolean {
+  if (!categories || categories.length === 0) {
+    return true;
+  }
+
+  return categories.includes(episode.category);
+}
+
+function filterByTags(episode: Episode, tags?: string[]): boolean {
+  if (!tags || tags.length === 0) {
+    return true;
+  }
+
+  return tags.every((tag) => episode.tags.includes(tag));
+}
+
+function sortEpisodes(data: Episode[], sort: EpisodeSort = 'newest'): Episode[] {
+  const sorted = [...data];
+
+  switch (sort) {
+    case 'oldest':
+      sorted.sort((a, b) => new Date(a.publishedAt).getTime() - new Date(b.publishedAt).getTime());
+      break;
+    case 'durationAsc':
+      sorted.sort((a, b) => a.durationSec - b.durationSec);
+      break;
+    case 'durationDesc':
+      sorted.sort((a, b) => b.durationSec - a.durationSec);
+      break;
+    case 'newest':
+    default:
+      sorted.sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
+      break;
+  }
+
+  return sorted;
+}
+
+function paginate<T>(data: T[], page: number, pageSize: number): T[] {
+  const start = (page - 1) * pageSize;
+  const end = start + pageSize;
+  return data.slice(start, end);
+}
+
+function computeMetadata(source: Episode[]): EpisodeFiltersMetadata {
+  const categoryMap = new Map<EpisodeCategory, number>();
+  const tagMap = new Map<string, number>();
+
+  for (const episode of source) {
+    categoryMap.set(episode.category, (categoryMap.get(episode.category) ?? 0) + 1);
+
+    for (const tag of episode.tags) {
+      tagMap.set(tag, (tagMap.get(tag) ?? 0) + 1);
+    }
+  }
+
+  return {
+    categories: Array.from(categoryMap.entries()).map(([value, count]) => ({ value, count })),
+    tags: Array.from(tagMap.entries())
+      .map(([value, count]) => ({ value, count }))
+      .sort((a, b) => a.value.localeCompare(b.value))
+  };
+}
+
+function getDefaultedQuery(query: EpisodeQuery = {}): Required<Pick<EpisodeQuery, 'page' | 'pageSize' | 'sort'>> & EpisodeQuery {
+  return {
+    page: query.page && query.page > 0 ? query.page : 1,
+    pageSize: query.pageSize && query.pageSize > 0 ? query.pageSize : 10,
+    sort: query.sort ?? 'newest',
+    ...query
+  };
+}
+
+function getLocalEpisodes(query: EpisodeQuery = {}): EpisodeQueryResult {
+  const { q, categories, tags, sort, page, pageSize } = getDefaultedQuery(query);
+
+  const metadata = computeMetadata(LOCAL_EPISODES);
+
+  const filtered = LOCAL_EPISODES.filter((episode) => {
+    const matchesSearch = q ? matchesQuery(episode, q) : true;
+    return matchesSearch && filterByCategories(episode, categories) && filterByTags(episode, tags);
+  });
+
+  const sorted = sortEpisodes(filtered, sort);
+  const paged = paginate(sorted, page, pageSize);
+
+  return {
+    episodes: paged,
+    total: filtered.length,
+    page,
+    pageSize,
+    metadata
+  };
+}
+
+function escapeLikeValue(value: string): string {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
+async function getSupabaseMetadata(client: SupabaseClient): Promise<EpisodeFiltersMetadata> {
+  const { data, error } = await client.from('episodes').select('category,tags');
+
+  if (error) {
+    throw error;
+  }
+
+  const mapped: Episode[] = (data ?? []).map((item) => ({
+    id: '',
+    title: '',
+    slug: '',
+    category: item.category as EpisodeCategory,
+    tags: (item.tags as string[]) ?? [],
+    description: '',
+    durationSec: 0,
+    audioUrl: '',
+    publishedAt: new Date().toISOString()
+  }));
+
+  return computeMetadata(mapped);
+}
+
+async function getSupabaseEpisodes(client: SupabaseClient, query: EpisodeQuery = {}): Promise<EpisodeQueryResult> {
+  const { q, categories, tags, sort, page, pageSize } = getDefaultedQuery(query);
+
+  let builder = client.from('episodes').select('*', { count: 'exact' });
+
+  if (q) {
+    const escaped = escapeLikeValue(q.trim());
+    builder = builder.or(`title.ilike.%${escaped}%,description.ilike.%${escaped}%`);
+  }
+
+  if (categories && categories.length > 0) {
+    builder = builder.in('category', categories);
+  }
+
+  if (tags && tags.length > 0) {
+    builder = builder.contains('tags', tags);
+  }
+
+  switch (sort) {
+    case 'oldest':
+      builder = builder.order('publishedAt', { ascending: true });
+      break;
+    case 'durationAsc':
+      builder = builder.order('durationSec', { ascending: true });
+      break;
+    case 'durationDesc':
+      builder = builder.order('durationSec', { ascending: false });
+      break;
+    case 'newest':
+    default:
+      builder = builder.order('publishedAt', { ascending: false });
+      break;
+  }
+
+  const rangeStart = (page - 1) * pageSize;
+  const rangeEnd = rangeStart + pageSize - 1;
+  builder = builder.range(rangeStart, rangeEnd);
+
+  const [{ data, error, count }, metadata] = await Promise.all([
+    builder,
+    getSupabaseMetadata(client)
+  ]);
+
+  if (error) {
+    throw error;
+  }
+
+  return {
+    episodes: (data as Episode[]) ?? [],
+    total: count ?? 0,
+    page,
+    pageSize,
+    metadata
+  };
+}
+
+export async function getEpisodes(query: EpisodeQuery = {}): Promise<EpisodeQueryResult> {
+  const client = await getSupabaseClient();
+
+  if (!client) {
+    return getLocalEpisodes(query);
+  }
+
+  try {
+    return await getSupabaseEpisodes(client, query);
+  } catch (error) {
+    console.warn('[analysis-archive] Failed to load data from Supabase, falling back to local JSON.', error);
+    return getLocalEpisodes(query);
+  }
+}

--- a/src/features/analysis-archive/data.local.json
+++ b/src/features/analysis-archive/data.local.json
@@ -1,0 +1,210 @@
+[
+  {
+    "id": "analysis-001",
+    "title": "Akt Darowania: początki narracji",
+    "slug": "akt-darowania-poczatki",
+    "category": "AktDarowania",
+    "tags": ["wprowadzenie", "psychologia", "strategie"],
+    "description": "Pierwsze spotkanie z cyklem Audycji Analitycznych tłumaczące podstawowe mechanizmy manipulacji oraz emocjonalnego uzależniania.",
+    "durationSec": 1845,
+    "audioUrl": "https://cdn.adamowo.org/audio/analysis/akt-darowania-1.mp3",
+    "coverUrl": "https://cdn.adamowo.org/covers/analysis/akt-darowania-1.jpg",
+    "publishedAt": "2024-01-12T08:00:00.000Z",
+    "chapters": [
+      { "title": "Wprowadzenie", "startSec": 0 },
+      { "title": "Definicje i kontekst", "startSec": 210 },
+      { "title": "Przykłady sytuacyjne", "startSec": 960 }
+    ],
+    "resources": [
+      { "label": "Notatki do odcinka", "url": "https://adamowo.org/notatki/akt-darowania-1" }
+    ]
+  },
+  {
+    "id": "analysis-002",
+    "title": "Służebność Uwiązania: eskalacja",
+    "slug": "sluzebnosc-uwiazania-eskalacja",
+    "category": "SłużebnośćUwiązania",
+    "tags": ["relacje", "escalacja"],
+    "description": "Analiza działań prowadzących do eskalacji zależności psychicznej oraz sposobów rozpoznawania czerwonych flag.",
+    "durationSec": 2312,
+    "audioUrl": "https://cdn.adamowo.org/audio/analysis/sluzebnosc-uwiazania-2.mp3",
+    "coverUrl": "https://cdn.adamowo.org/covers/analysis/sluzebnosc-uwiazania-2.jpg",
+    "publishedAt": "2024-01-26T08:00:00.000Z",
+    "chapters": [
+      { "title": "Wywiad ekspercki", "startSec": 60 },
+      { "title": "Studium przypadku", "startSec": 780 },
+      { "title": "Rekomendacje", "startSec": 1890 }
+    ],
+    "resources": [
+      { "label": "Artykuł naukowy", "url": "https://adamowo.org/baza/escalacja" }
+    ]
+  },
+  {
+    "id": "analysis-003",
+    "title": "Sprawa Adamskich: timeline zdarzeń",
+    "slug": "sprawa-adamskich-timeline",
+    "category": "SprawaAdamskich",
+    "tags": ["case-study", "rodzina"],
+    "description": "Szczegółowa rekonstrukcja wydarzeń w sprawie Adamskich, z naciskiem na momenty przełomowe.",
+    "durationSec": 2670,
+    "audioUrl": "https://cdn.adamowo.org/audio/analysis/sprawa-adamskich-1.mp3",
+    "publishedAt": "2024-02-02T08:00:00.000Z",
+    "chapters": [
+      { "title": "Wprowadzenie do akt", "startSec": 0 },
+      { "title": "Analiza dokumentów", "startSec": 540 },
+      { "title": "Głosy świadków", "startSec": 1500 }
+    ],
+    "resources": [
+      { "label": "Teczka sprawy", "url": "https://adamowo.org/sprawa-adamskich" }
+    ]
+  },
+  {
+    "id": "analysis-004",
+    "title": "Broń Narcyza: język dominacji",
+    "slug": "bron-narcyza-jezyk",
+    "category": "BronNarcyza",
+    "tags": ["manipulacja", "język"],
+    "description": "Rozłożenie na czynniki pierwsze języka, którym narcyzi budują iluzję kontroli i wyższości.",
+    "durationSec": 1984,
+    "audioUrl": "https://cdn.adamowo.org/audio/analysis/bron-narcyza-1.mp3",
+    "publishedAt": "2024-02-16T08:00:00.000Z",
+    "chapters": [
+      { "title": "Mechanizmy językowe", "startSec": 20 },
+      { "title": "Techniki wpływu", "startSec": 780 },
+      { "title": "Przeciwdziałanie", "startSec": 1530 }
+    ],
+    "resources": [
+      { "label": "Lista technik językowych", "url": "https://adamowo.org/bron-narcyza" }
+    ]
+  },
+  {
+    "id": "analysis-005",
+    "title": "Śledztwo: notatki terenowe",
+    "slug": "sledztwo-notatki-terenowe",
+    "category": "Sledztwo",
+    "tags": ["teren", "weryfikacja", "procedury"],
+    "description": "Podsumowanie pracy terenowej zespołu śledczego, z naciskiem na metodologię i bezpieczeństwo informatorów.",
+    "durationSec": 2466,
+    "audioUrl": "https://cdn.adamowo.org/audio/analysis/sledztwo-1.mp3",
+    "publishedAt": "2024-03-01T08:00:00.000Z",
+    "chapters": [
+      { "title": "Protokół bezpieczeństwa", "startSec": 120 },
+      { "title": "Mapowanie relacji", "startSec": 920 },
+      { "title": "Wnioski", "startSec": 1980 }
+    ]
+  },
+  {
+    "id": "analysis-006",
+    "title": "Akt Darowania: konfrontacja",
+    "slug": "akt-darowania-konfrontacja",
+    "category": "AktDarowania",
+    "tags": ["konfrontacja", "narcyzm"],
+    "description": "Opis narzędzi konfrontacyjnych i sposobów stawiania granic w relacji opartej na akcie darowania.",
+    "durationSec": 2104,
+    "audioUrl": "https://cdn.adamowo.org/audio/analysis/akt-darowania-2.mp3",
+    "publishedAt": "2024-03-15T08:00:00.000Z",
+    "chapters": [
+      { "title": "Diagnoza sytuacji", "startSec": 0 },
+      { "title": "Plan działania", "startSec": 660 },
+      { "title": "Wsparcie specjalistyczne", "startSec": 1500 }
+    ],
+    "resources": [
+      { "label": "Checklist granic", "url": "https://adamowo.org/granice-checklist" }
+    ]
+  },
+  {
+    "id": "analysis-007",
+    "title": "Broń Narcyza: cyfrowe tropy",
+    "slug": "bron-narcyza-cyfrowe-tropy",
+    "category": "BronNarcyza",
+    "tags": ["cyber", "monitoring"],
+    "description": "Śledzenie cyfrowych śladów narcyzów oraz analiza narzędzi do monitorowania ofiar w sieci.",
+    "durationSec": 2240,
+    "audioUrl": "https://cdn.adamowo.org/audio/analysis/bron-narcyza-2.mp3",
+    "publishedAt": "2024-03-29T08:00:00.000Z",
+    "chapters": [
+      { "title": "Narzędzia kontroli", "startSec": 140 },
+      { "title": "Anonimizacja", "startSec": 900 },
+      { "title": "Wsparcie prawne", "startSec": 1620 }
+    ],
+    "resources": [
+      { "label": "Pakiet bezpieczeństwa cyfrowego", "url": "https://adamowo.org/bezpieczenstwo-cyfrowe" }
+    ]
+  },
+  {
+    "id": "analysis-008",
+    "title": "Służebność Uwiązania: ślady ekonomiczne",
+    "slug": "sluzebnosc-uwiazania-ekonomia",
+    "category": "SłużebnośćUwiązania",
+    "tags": ["finanse", "kontrola"],
+    "description": "Analiza wzorców ekonomicznych wskazujących na uwiązanie finansowe oraz sposoby reagowania.",
+    "durationSec": 2055,
+    "audioUrl": "https://cdn.adamowo.org/audio/analysis/sluzebnosc-uwiazania-3.mp3",
+    "publishedAt": "2024-04-12T08:00:00.000Z",
+    "chapters": [
+      { "title": "Typowe schematy", "startSec": 30 },
+      { "title": "Budżet ratunkowy", "startSec": 750 },
+      { "title": "Wsparcie instytucjonalne", "startSec": 1500 }
+    ]
+  },
+  {
+    "id": "analysis-009",
+    "title": "Sprawa Adamskich: proces sądowy",
+    "slug": "sprawa-adamskich-proces",
+    "category": "SprawaAdamskich",
+    "tags": ["prawo", "orzecznictwo"],
+    "description": "Przegląd kluczowych rozpraw w procesie Adamskich i analiza zeznań świadków.",
+    "durationSec": 2520,
+    "audioUrl": "https://cdn.adamowo.org/audio/analysis/sprawa-adamskich-2.mp3",
+    "publishedAt": "2024-04-26T08:00:00.000Z",
+    "chapters": [
+      { "title": "Przygotowanie obrony", "startSec": 120 },
+      { "title": "Linie argumentacyjne", "startSec": 840 },
+      { "title": "Orzeczenie", "startSec": 2040 }
+    ]
+  },
+  {
+    "id": "analysis-010",
+    "title": "Śledztwo: analiza sygnałów",
+    "slug": "sledztwo-analiza-sygnalow",
+    "category": "Sledztwo",
+    "tags": ["analiza", "sygnały"],
+    "description": "Zestawienie sygnałów ostrzegawczych pojawiających się w zgłoszeniach i ich weryfikacja.",
+    "durationSec": 2386,
+    "audioUrl": "https://cdn.adamowo.org/audio/analysis/sledztwo-2.mp3",
+    "publishedAt": "2024-05-10T08:00:00.000Z"
+  },
+  {
+    "id": "analysis-011",
+    "title": "Akt Darowania: odbudowa",
+    "slug": "akt-darowania-odbudowa",
+    "category": "AktDarowania",
+    "tags": ["regeneracja", "wsparcie"],
+    "description": "Strategie odbudowy własnej autonomii po zakończeniu relacji opartej na darowaniu.",
+    "durationSec": 2150,
+    "audioUrl": "https://cdn.adamowo.org/audio/analysis/akt-darowania-3.mp3",
+    "publishedAt": "2024-05-24T08:00:00.000Z",
+    "resources": [
+      { "label": "Plan odbudowy", "url": "https://adamowo.org/odbudowa-plan" }
+    ]
+  },
+  {
+    "id": "analysis-012",
+    "title": "Broń Narcyza: architektura kłamstwa",
+    "slug": "bron-narcyza-architektura-klamstwa",
+    "category": "BronNarcyza",
+    "tags": ["kłamstwo", "propaganda", "dezinformacja"],
+    "description": "Przegląd technik dezinformacyjnych i sposobów reagowania na zmasowane kampanie kłamstw.",
+    "durationSec": 2425,
+    "audioUrl": "https://cdn.adamowo.org/audio/analysis/bron-narcyza-3.mp3",
+    "publishedAt": "2024-06-07T08:00:00.000Z",
+    "chapters": [
+      { "title": "Źródła kłamstw", "startSec": 0 },
+      { "title": "Reakcje społeczności", "startSec": 880 },
+      { "title": "Strategie odporności", "startSec": 1710 }
+    ],
+    "resources": [
+      { "label": "Przewodnik odporności", "url": "https://adamowo.org/odpornosc" }
+    ]
+  }
+]

--- a/src/features/analysis-archive/data.schema.ts
+++ b/src/features/analysis-archive/data.schema.ts
@@ -1,0 +1,50 @@
+export type Chapter = {
+  title: string;
+  startSec: number;
+};
+
+export type EpisodeCategory =
+  | 'AktDarowania'
+  | 'SlużebnośćUwiązania'
+  | 'SprawaAdamskich'
+  | 'BronNarcyza'
+  | 'Sledztwo';
+
+export type Episode = {
+  id: string;
+  title: string;
+  slug: string;
+  category: EpisodeCategory;
+  tags: string[];
+  description: string;
+  durationSec: number;
+  audioUrl: string;
+  coverUrl?: string;
+  publishedAt: string;
+  chapters?: Chapter[];
+  resources?: { label: string; url: string }[];
+};
+
+export type EpisodeSort = 'newest' | 'oldest' | 'durationAsc' | 'durationDesc';
+
+export type EpisodeQuery = {
+  q?: string;
+  categories?: EpisodeCategory[];
+  tags?: string[];
+  sort?: EpisodeSort;
+  page?: number;
+  pageSize?: number;
+};
+
+export type EpisodeFiltersMetadata = {
+  categories: { value: EpisodeCategory; count: number }[];
+  tags: { value: string; count: number }[];
+};
+
+export type EpisodeQueryResult = {
+  episodes: Episode[];
+  total: number;
+  page: number;
+  pageSize: number;
+  metadata: EpisodeFiltersMetadata;
+};

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -46,5 +46,70 @@
       "current": "Currently: {{value}}",
       "resolved_dark": "dark mode",
       "resolved_light": "light mode"
+    }
+  },
+  "analysis": {
+    "page": {
+      "title": "Analytical Broadcasts",
+      "lead": "Explore investigations and commentary on manipulation and control."
     },
+    "filters": {
+      "title": "Filters",
+      "results": "{{count}} results",
+      "searchLabel": "Search episodes",
+      "searchPlaceholder": "Search title or description...",
+      "categoriesLabel": "Categories",
+      "tagsLabel": "Tags",
+      "sortLabel": "Sort",
+      "sortNewest": "Newest first",
+      "sortOldest": "Oldest first",
+      "sortDurationAsc": "Shortest duration",
+      "sortDurationDesc": "Longest duration"
+    },
+    "categories": {
+      "AktDarowania": "Act of Giving",
+      "SłużebnośćUwiązania": "Servitude of Binding",
+      "SprawaAdamskich": "Adamski Case",
+      "BronNarcyza": "Narcissus' Weapon",
+      "Sledztwo": "Investigation"
+    },
+    "actions": {
+      "listen": "Listen",
+      "listenEpisode": "Listen to {{title}}",
+      "currentlyPlaying": "Now playing"
+    },
+    "list": {
+      "ariaLabel": "Analysis episodes"
+    },
+    "state": {
+      "loading": "Loading episodes...",
+      "empty": "No episodes match the filters yet."
+    },
+    "pagination": {
+      "pageIndicator": "Page {{page}} of {{pages}}",
+      "previous": "Previous",
+      "next": "Next"
+    },
+    "player": {
+      "title": "Episode player",
+      "play": "Play",
+      "pause": "Pause",
+      "mute": "Mute",
+      "unmute": "Unmute",
+      "volume": "Volume",
+      "progress": "Playback progress",
+      "nowPlaying": "Now playing: {{title}}",
+      "idle": "Select an episode to start listening",
+      "chapters": "Chapters"
+    },
+    "details": {
+      "emptyTitle": "Episode details",
+      "emptyHint": "Choose an episode from the list to see its description and materials.",
+      "published": "Published: {{date}}",
+      "unknownDate": "unknown",
+      "chapters": "Chapters",
+      "seekTo": "Jump to chapter {{title}}",
+      "resources": "Resources"
+    }
+  }
 }

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -46,5 +46,70 @@
       "current": "Actueel: {{value}}",
       "resolved_dark": "donkere modus",
       "resolved_light": "lichte modus"
+    }
+  },
+  "analysis": {
+    "page": {
+      "title": "Analytische uitzendingen",
+      "lead": "Ontdek onderzoeken en commentaar over manipulatie en controle."
     },
+    "filters": {
+      "title": "Filters",
+      "results": "{{count}} resultaten",
+      "searchLabel": "Zoek aflevering",
+      "searchPlaceholder": "Titel of beschrijving...",
+      "categoriesLabel": "Categorieën",
+      "tagsLabel": "Tags",
+      "sortLabel": "Sortering",
+      "sortNewest": "Nieuwste eerst",
+      "sortOldest": "Oudste eerst",
+      "sortDurationAsc": "Kortste duur",
+      "sortDurationDesc": "Langste duur"
+    },
+    "categories": {
+      "AktDarowania": "Act van Schenking",
+      "SłużebnośćUwiązania": "Dienstbaarheid van Gebondenheid",
+      "SprawaAdamskich": "Zaak Adamski",
+      "BronNarcyza": "Wapen van de Narcist",
+      "Sledztwo": "Onderzoek"
+    },
+    "actions": {
+      "listen": "Luister",
+      "listenEpisode": "Luister naar {{title}}",
+      "currentlyPlaying": "Nu aan het afspelen"
+    },
+    "list": {
+      "ariaLabel": "Analyse-afleveringen"
+    },
+    "state": {
+      "loading": "Afleveringen laden...",
+      "empty": "Geen afleveringen voldoen aan de filters."
+    },
+    "pagination": {
+      "pageIndicator": "Pagina {{page}} van {{pages}}",
+      "previous": "Vorige",
+      "next": "Volgende"
+    },
+    "player": {
+      "title": "Afleveringsspeler",
+      "play": "Afspelen",
+      "pause": "Pauze",
+      "mute": "Dempen",
+      "unmute": "Geluid aan",
+      "volume": "Volume",
+      "progress": "Voortgang",
+      "nowPlaying": "Nu speelt: {{title}}",
+      "idle": "Kies een aflevering om te starten",
+      "chapters": "Hoofdstukken"
+    },
+    "details": {
+      "emptyTitle": "Details van de aflevering",
+      "emptyHint": "Kies een aflevering uit de lijst voor beschrijving en bronnen.",
+      "published": "Gepubliceerd: {{date}}",
+      "unknownDate": "onbekend",
+      "chapters": "Hoofdstukken",
+      "seekTo": "Spring naar hoofdstuk {{title}}",
+      "resources": "Bronnen"
+    }
+  }
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -46,5 +46,70 @@
       "current": "Aktualnie: {{value}}",
       "resolved_dark": "tryb ciemny",
       "resolved_light": "tryb jasny"
+    }
+  },
+  "analysis": {
+    "page": {
+      "title": "Audycje Analityczne",
+      "lead": "Przegląd analiz, śledztw i komentarzy o mechanizmach kontroli."
     },
+    "filters": {
+      "title": "Filtry",
+      "results": "Znaleziono {{count}} wyników",
+      "searchLabel": "Szukaj odcinka",
+      "searchPlaceholder": "Tytuł lub opis...",
+      "categoriesLabel": "Kategorie",
+      "tagsLabel": "Tagi",
+      "sortLabel": "Sortowanie",
+      "sortNewest": "Najnowsze",
+      "sortOldest": "Najstarsze",
+      "sortDurationAsc": "Najkrótszy czas",
+      "sortDurationDesc": "Najdłuższy czas"
+    },
+    "categories": {
+      "AktDarowania": "Akt Darowania",
+      "SłużebnośćUwiązania": "Służebność Uwiązania",
+      "SprawaAdamskich": "Sprawa Adamskich",
+      "BronNarcyza": "Broń Narcyza",
+      "Sledztwo": "Śledztwo"
+    },
+    "actions": {
+      "listen": "Słuchaj",
+      "listenEpisode": "Słuchaj: {{title}}",
+      "currentlyPlaying": "Odtwarzanie"
+    },
+    "list": {
+      "ariaLabel": "Lista odcinków analitycznych"
+    },
+    "state": {
+      "loading": "Wczytywanie odcinków...",
+      "empty": "Brak odcinków spełniających wybrane filtry."
+    },
+    "pagination": {
+      "pageIndicator": "Strona {{page}} z {{pages}}",
+      "previous": "Poprzednia",
+      "next": "Następna"
+    },
+    "player": {
+      "title": "Odtwarzacz analizy",
+      "play": "Odtwórz",
+      "pause": "Pauza",
+      "mute": "Wycisz",
+      "unmute": "Włącz dźwięk",
+      "volume": "Głośność",
+      "progress": "Postęp odtwarzania",
+      "nowPlaying": "Odtwarzane: {{title}}",
+      "idle": "Wybierz odcinek, aby rozpocząć",
+      "chapters": "Rozdziały"
+    },
+    "details": {
+      "emptyTitle": "Szczegóły odcinka",
+      "emptyHint": "Wybierz odcinek z listy, aby zobaczyć opis i materiały.",
+      "published": "Data publikacji: {{date}}",
+      "unknownDate": "brak danych",
+      "chapters": "Rozdziały",
+      "seekTo": "Przeskocz do rozdziału {{title}}",
+      "resources": "Materiały"
+    }
+  }
 }

--- a/src/pages/Guides.tsx
+++ b/src/pages/Guides.tsx
@@ -1,14 +1,28 @@
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 
 export default function Guides(): JSX.Element {
   const { t } = useTranslation();
 
   return (
-    <section>
-      <h1 className="text-3xl font-bold text-base-50 sm:text-4xl">{t('pages.guides.title')}</h1>
-      <p className="mt-4 max-w-2xl text-base-200">
-        Guidance and educational modules will appear here.
-      </p>
+    <section className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-base-50 sm:text-4xl">{t('pages.guides.title')}</h1>
+        <p className="mt-4 max-w-2xl text-base-200">
+          Guidance and educational modules will appear here.
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-base-800 bg-base-900/40 p-6 text-base-100">
+        <h2 className="text-xl font-semibold text-accent-300">{t('analysis.page.title')}</h2>
+        <p className="mt-2 text-sm text-base-300">{t('analysis.page.lead')}</p>
+        <Link
+          to="/analysis"
+          className="mt-4 inline-flex items-center justify-center rounded-full border border-accent-400 px-5 py-2 text-sm font-semibold text-accent-200 transition hover:bg-accent-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400"
+        >
+          {t('analysis.actions.listen')}
+        </Link>
+      </div>
     </section>
   );
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -8,6 +8,7 @@ import Lab from './pages/Lab';
 import Live from './pages/Live';
 import Shows from './pages/Shows';
 import ViolenceLoop from './pages/ViolenceLoop';
+import AnalysisPage from './features/analysis-archive/AnalysisPage';
 
 export const router = createBrowserRouter([
   {
@@ -18,6 +19,7 @@ export const router = createBrowserRouter([
       { path: 'live', element: <Live /> },
       { path: 'violence-loop', element: <ViolenceLoop /> },
       { path: 'shows', element: <Shows /> },
+      { path: 'analysis', element: <AnalysisPage /> },
       { path: 'guides', element: <Guides /> },
       { path: 'lab', element: <Lab /> },
       { path: 'community', element: <Community /> }


### PR DESCRIPTION
## Summary
- add the analysis archive page with filter state, paginated episode list, and details/player layout
- implement an accessible episode player with chapter markers and wire episode details to chapter jumps
- provide a Supabase-aware data client with local JSON fallback, translations, README env notes, and regression tests for filters and playback selection

## Testing
- `ESLINT_USE_FLAT_CONFIG=true node_modules/.bin/eslint . --max-warnings=0` *(fails: existing repository lint configuration reports JSX globals missing across unrelated files)*
- `node_modules/.bin/vitest run` *(fails: Vitest cannot load the jsdom environment in the offline container)*

------
https://chatgpt.com/codex/tasks/task_e_68db1a1b81c48322a6351fab4536e569