### PR TITLE
Add documentary experience with final lesson and footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Aplikacja uruchomi się pod adresem `http://localhost:5173`.
 - Dostępne przełączniki motywu i języka.
 - Translacje dla PL/NL/EN z autodetekcją języka przeglądarki.
 
+## Konfiguracja materiału dokumentalnego
+- Ustaw adresy strumienia w pliku `.env` lub `.env.local`:
+  - `VITE_DOC_VIDEO_HLS` – adres playlisty HLS (`.m3u8`).
+  - `VITE_DOC_VIDEO_MP4` – adres pliku MP4 używany jako fallback.
+  - `VITE_DOC_SUBTITLES_VTT` – opcjonalna ścieżka do napisów w formacie WebVTT.
+- Gdy brak źródła HLS/MP4, sekcja wyświetla komunikat konfiguracyjny oraz wyłączony odtwarzacz.
+- Metadane (rozdziały, materiały dodatkowe) znajdują się w `src/features/documentary/doc.data.ts` i są tłumaczone przez klucze w `src/i18n/*`.
+- Napisy można dodać przez umieszczenie plików `.vtt` w katalogu `public/assets/...` i wskazanie ich ścieżki w zmiennej `VITE_DOC_SUBTITLES_VTT`.
+
 ### Kocioł Wiedźmy: Pętla Przemocy
 - Animowany diagram nieskończoności wykorzystuje pętlę o długości ~14 s z możliwością pauzy, resetu oraz ręcznego wyboru fazy.
 - Przy włączonym systemowym `prefers-reduced-motion` animacja startuje w stanie pauzy, a w UI dostępny jest przełącznik "Ogranicz animacje".

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "clsx": "^2.1.1",
     "i18next": "^23.11.5",
     "i18next-browser-languagedetector": "^7.2.0",
+    "hls.js": "^1.5.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^13.5.0",

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -2,6 +2,7 @@ import { Outlet } from 'react-router-dom';
 
 import { useTranslation } from 'react-i18next';
 
+import { AppFooter } from '../features/footer/AppFooter';
 import { Header } from './Header';
 
 export function AppShell(): JSX.Element {
@@ -23,6 +24,7 @@ export function AppShell(): JSX.Element {
       >
         <Outlet />
       </main>
+      <AppFooter />
     </div>
   );
 }

--- a/src/features/documentary/DocumentarySection.test.tsx
+++ b/src/features/documentary/DocumentarySection.test.tsx
@@ -1,0 +1,72 @@
+import { screen } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { DocumentarySection } from './DocumentarySection';
+import { renderWithI18n } from '../../test/utils';
+
+vi.mock('hls.js', () => {
+  class MockHls {
+    static Events = { MEDIA_ATTACHED: 'MEDIA_ATTACHED', ERROR: 'ERROR' } as const;
+
+    static isSupported(): boolean {
+      return true;
+    }
+
+    attachMedia(): void {}
+
+    loadSource(): void {}
+
+    on(event: string, handler: () => void): void {
+      if (event === MockHls.Events.MEDIA_ATTACHED) {
+        handler();
+      }
+    }
+
+    destroy(): void {}
+  }
+
+  return { default: MockHls };
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('DocumentarySection', () => {
+  test('renders documentary player with resources when HLS is configured', async () => {
+    vi.stubEnv('VITE_DOC_VIDEO_HLS', 'https://example.com/doc.m3u8');
+    vi.stubEnv('VITE_DOC_VIDEO_MP4', 'https://example.com/doc.mp4');
+    vi.stubEnv('VITE_DOC_SUBTITLES_VTT', '/subs/pl.vtt');
+
+    await renderWithI18n(<DocumentarySection />);
+
+    expect(
+      screen.getByRole('heading', { name: 'The Adamowo Case: Autopsy of a Family War' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Loading documentary…')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Case timeline/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Disable subtitles' })).toBeInTheDocument();
+  });
+
+  test('renders fallback MP4 without configuration warning', async () => {
+    vi.stubEnv('VITE_DOC_VIDEO_MP4', 'https://example.com/doc.mp4');
+
+    await renderWithI18n(<DocumentarySection />);
+
+    expect(
+      screen.queryByText(
+        'Configure environment variables VITE_DOC_VIDEO_HLS or VITE_DOC_VIDEO_MP4 to publish the stream.'
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  test('shows configuration hint when no sources are provided', async () => {
+    await renderWithI18n(<DocumentarySection />);
+
+    expect(
+      screen.getByText(
+        'Configure environment variables VITE_DOC_VIDEO_HLS or VITE_DOC_VIDEO_MP4 to publish the stream.'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/documentary/DocumentarySection.tsx
+++ b/src/features/documentary/DocumentarySection.tsx
@@ -1,0 +1,179 @@
+import { useMemo } from 'react';
+import type { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { documentaryMeta } from './doc.data';
+import type { DocResource } from './doc.schema';
+import { VideoPlayer } from './VideoPlayer';
+import type { VideoChapter } from './VideoPlayer';
+
+const resourceTypeIcon: Record<DocResource['type'], string> = {
+  pdf: '📄',
+  article: '📰',
+  audio: '🎧',
+  guide: '🧭',
+  video: '🎬'
+};
+
+export function DocumentarySection(): ReactElement {
+  const { t } = useTranslation();
+
+  const hlsSource = import.meta.env.VITE_DOC_VIDEO_HLS as string | undefined;
+  const mp4Source = import.meta.env.VITE_DOC_VIDEO_MP4 as string | undefined;
+  const subtitlesSrc = import.meta.env.VITE_DOC_SUBTITLES_VTT as string | undefined;
+
+  const resources = useMemo(
+    () =>
+      documentaryMeta.resources.map((resource) => ({
+        ...resource,
+        title: t(resource.titleKey),
+        description: t(resource.descriptionKey),
+        typeLabel: t(`documentary.resourceTypes.${resource.type}`)
+      })),
+    [t]
+  );
+
+  const chapters = useMemo(
+    () =>
+      documentaryMeta.chapters.map((chapter) => ({
+        ...chapter,
+        title: t(chapter.titleKey),
+        summary: chapter.summaryKey ? (t(chapter.summaryKey) as string) : undefined
+      })),
+    [t]
+  );
+
+  const subtitleTracks = useMemo(() => {
+    if (!subtitlesSrc) {
+      return undefined;
+    }
+
+    return [
+      {
+        id: 'primary-subtitles',
+        label: t('documentary.subtitles.primaryLabel'),
+        src: subtitlesSrc,
+        srclang: t('documentary.subtitles.primaryCode'),
+        kind: 'subtitles' as const,
+        default: true
+      }
+    ];
+  }, [subtitlesSrc, t]);
+
+  const statusMessages = useMemo(
+    () => ({
+      loading: t('documentary.player.status.loading'),
+      error: t('documentary.player.status.error'),
+      noSource: t('documentary.player.status.noSource')
+    }),
+    [t]
+  );
+
+  const labels = useMemo(
+    () => ({
+      controlsGroup: t('documentary.player.controlsGroup'),
+      play: t('documentary.player.play'),
+      pause: t('documentary.player.pause'),
+      mute: t('documentary.player.mute'),
+      unmute: t('documentary.player.unmute'),
+      subtitlesOn: t('documentary.player.subtitlesOn'),
+      subtitlesOff: t('documentary.player.subtitlesOff'),
+      subtitlesUnavailable: t('documentary.player.subtitlesUnavailable'),
+      enterFullscreen: t('documentary.player.enterFullscreen'),
+      exitFullscreen: t('documentary.player.exitFullscreen'),
+      progress: t('documentary.player.progress'),
+      volume: t('documentary.player.volume'),
+      volumeIndicator: (value: number) =>
+        t('documentary.player.volumeIndicator', { value: Math.round(value * 100) }),
+      chapterHeading: t('documentary.player.chaptersHeading'),
+      chapterCurrent: t('documentary.player.chapterCurrent'),
+      getChapterAriaLabel: (chapter: VideoChapter, formattedTime: string) =>
+        t('documentary.player.chapterAriaLabel', {
+          title: chapter.title,
+          time: formattedTime
+        })
+    }),
+    [t]
+  );
+
+  const noSourceConfigured = !hlsSource && !mp4Source;
+
+  return (
+    <section
+      role="region"
+      aria-labelledby="documentary-heading"
+      className="rounded-3xl border border-base-800/70 bg-base-950/60 px-4 py-8 shadow-[0_30px_80px_rgba(10,14,39,0.45)] backdrop-blur-lg sm:px-6 lg:px-10"
+    >
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-10">
+        <header className="space-y-4 text-base-100">
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-accent-300">
+            {t('documentary.sectionLabel')}
+          </p>
+          <h2 id="documentary-heading" className="text-3xl font-semibold text-base-50 sm:text-4xl">
+            {t(documentaryMeta.titleKey)}
+          </h2>
+          <p className="max-w-3xl text-base-200">{t(documentaryMeta.descriptionKey)}</p>
+          {noSourceConfigured ? (
+            <p className="max-w-2xl rounded-lg border border-dashed border-accent-500/60 bg-accent-500/10 p-4 text-sm text-accent-200">
+              {t('documentary.player.status.configurationHint')}
+            </p>
+          ) : null}
+        </header>
+
+        <div className="grid gap-10 lg:grid-cols-5">
+          <div className="lg:col-span-3">
+            <VideoPlayer
+              title={t(documentaryMeta.titleKey)}
+              hlsSrc={hlsSource}
+              mp4Src={mp4Source}
+              poster={documentaryMeta.poster}
+              chapters={chapters}
+              subtitleTracks={subtitleTracks}
+              statusMessages={statusMessages}
+              labels={labels}
+            />
+          </div>
+
+          <aside
+            className="space-y-4 rounded-2xl border border-base-800/70 bg-base-950/40 p-6"
+            aria-labelledby="documentary-materials"
+          >
+            <div className="space-y-2">
+              <h3 id="documentary-materials" className="text-lg font-semibold text-base-50">
+                {t('documentary.resources.heading')}
+              </h3>
+              <p className="text-sm text-base-300">{t('documentary.resources.description')}</p>
+            </div>
+
+            <ul className="space-y-4">
+              {resources.map((resource) => (
+                <li key={resource.id} className="rounded-xl border border-base-800/60 bg-base-900/50 p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <h4 className="text-base font-semibold text-base-100">
+                        <a
+                          href={resource.url}
+                          className="inline-flex items-center gap-2 text-base-100 underline decoration-accent-500 decoration-2 underline-offset-4 transition hover:text-accent-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400"
+                          target="_blank"
+                          rel="noreferrer"
+                          aria-label={`${resource.title} – ${resource.typeLabel}`}
+                        >
+                          <span aria-hidden="true">{resourceTypeIcon[resource.type]}</span>
+                          <span>{resource.title}</span>
+                        </a>
+                      </h4>
+                      <p className="mt-1 text-sm text-base-300">{resource.description}</p>
+                    </div>
+                    <span className="rounded-full border border-accent-500/40 bg-accent-500/10 px-3 py-1 text-xs font-medium uppercase tracking-wide text-accent-200">
+                      {resource.typeLabel}
+                    </span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/documentary/VideoPlayer.test.tsx
+++ b/src/features/documentary/VideoPlayer.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test, vi, beforeEach, afterAll } from 'vitest';
+
+import { VideoPlayer } from './VideoPlayer';
+import type { PlayerLabels } from './VideoPlayer';
+
+const playMock = vi.fn().mockImplementation(function (this: HTMLVideoElement) {
+  fireEvent(this, new Event('play'));
+  return Promise.resolve();
+});
+
+const pauseMock = vi.fn().mockImplementation(function (this: HTMLVideoElement) {
+  fireEvent(this, new Event('pause'));
+});
+
+const originalPlay = HTMLMediaElement.prototype.play;
+const originalPause = HTMLMediaElement.prototype.pause;
+
+vi.mock('hls.js', () => {
+  class MockHls {
+    static Events = { MEDIA_ATTACHED: 'MEDIA_ATTACHED', ERROR: 'ERROR' } as const;
+
+    static isSupported(): boolean {
+      return true;
+    }
+
+    attachMedia(): void {}
+
+    loadSource(): void {}
+
+    on(event: string, handler: () => void): void {
+      if (event === MockHls.Events.MEDIA_ATTACHED) {
+        handler();
+      }
+    }
+
+    destroy(): void {}
+  }
+
+  return { default: MockHls };
+});
+
+const statusMessages = {
+  loading: 'Loading',
+  error: 'Error',
+  noSource: 'No source'
+};
+
+const labels: PlayerLabels = {
+  controlsGroup: 'Video controls',
+  play: 'Play video',
+  pause: 'Pause video',
+  mute: 'Mute',
+  unmute: 'Unmute',
+  subtitlesOn: 'Enable subtitles',
+  subtitlesOff: 'Disable subtitles',
+  subtitlesUnavailable: 'Subtitles unavailable',
+  enterFullscreen: 'Enter fullscreen',
+  exitFullscreen: 'Exit fullscreen',
+  progress: 'Seek video',
+  volume: 'Adjust volume',
+  volumeIndicator: (value) => `Volume ${Math.round(value * 100)}%`,
+  chapterHeading: 'Chapters',
+  chapterCurrent: 'Current chapter',
+  getChapterAriaLabel: (chapter, time) => `${chapter.title} (${time})`
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+    configurable: true,
+    writable: true,
+    value: playMock
+  });
+  Object.defineProperty(HTMLMediaElement.prototype, 'pause', {
+    configurable: true,
+    writable: true,
+    value: pauseMock
+  });
+});
+
+afterAll(() => {
+  Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+    configurable: true,
+    writable: true,
+    value: originalPlay
+  });
+  Object.defineProperty(HTMLMediaElement.prototype, 'pause', {
+    configurable: true,
+    writable: true,
+    value: originalPause
+  });
+});
+
+describe('VideoPlayer', () => {
+  test('toggles playback on button click', async () => {
+    const user = userEvent.setup();
+
+    renderPlayer();
+
+    const playButton = screen.getByRole('button', { name: /play video/i });
+    await user.click(playButton);
+    expect(playMock).toHaveBeenCalledTimes(1);
+
+    const pauseButton = screen.getByRole('button', { name: /pause video/i });
+    await user.click(pauseButton);
+    expect(pauseMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows message when no source is provided', () => {
+    renderPlayer({ hlsSrc: undefined, mp4Src: undefined });
+
+    expect(screen.getByText('No source')).toBeInTheDocument();
+  });
+
+  test('seeks to chapter time when selected', async () => {
+    const user = userEvent.setup();
+
+    renderPlayer({ chapters: [{ id: 'intro', title: 'Intro', time: 120 }] });
+
+    const video = screen.getByTestId('documentary-video') as HTMLVideoElement;
+    fireEvent(video, new Event('loadedmetadata'));
+    fireEvent(video, new Event('canplay'));
+
+    const chapterButton = screen.getByRole('button', { name: /intro \(2:00\)/i });
+    await user.click(chapterButton);
+
+    expect(video.currentTime).toBe(120);
+  });
+});
+
+function renderPlayer(
+  overrides: Partial<{ hlsSrc?: string; mp4Src?: string; chapters: Array<{ id: string; title: string; time: number }> }> = {}
+) {
+  const { hlsSrc = 'https://example.com/doc.m3u8', mp4Src = 'https://example.com/doc.mp4', chapters = [] } = overrides;
+
+  return render(<VideoPlayer title="Documentary" hlsSrc={hlsSrc} mp4Src={mp4Src} chapters={chapters} statusMessages={statusMessages} labels={labels} />);
+}

--- a/src/features/documentary/VideoPlayer.tsx
+++ b/src/features/documentary/VideoPlayer.tsx
@@ -1,0 +1,532 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ChangeEvent, ReactElement } from 'react';
+import Hls from 'hls.js';
+
+export interface VideoChapter {
+  id: string;
+  title: string;
+  time: number;
+  summary?: string;
+}
+
+export interface SubtitleTrack {
+  id: string;
+  label: string;
+  src: string;
+  srclang: string;
+  kind?: SubtitleTrackKind;
+  default?: boolean;
+}
+
+export interface PlayerStatusMessages {
+  loading: string;
+  error: string;
+  noSource: string;
+}
+
+export interface PlayerLabels {
+  controlsGroup: string;
+  play: string;
+  pause: string;
+  mute: string;
+  unmute: string;
+  subtitlesOn: string;
+  subtitlesOff: string;
+  enterFullscreen: string;
+  exitFullscreen: string;
+  progress: string;
+  volume: string;
+  volumeIndicator: (value: number) => string;
+  subtitlesUnavailable: string;
+  chapterHeading: string;
+  chapterCurrent: string;
+  getChapterAriaLabel?: (chapter: VideoChapter, formattedTime: string) => string;
+}
+
+interface VideoPlayerProps {
+  title: string;
+  hlsSrc?: string;
+  mp4Src?: string;
+  poster?: string;
+  chapters: VideoChapter[];
+  subtitleTracks?: SubtitleTrack[];
+  statusMessages: PlayerStatusMessages;
+  labels: PlayerLabels;
+}
+
+type PlayerStatus = 'idle' | 'loading' | 'ready' | 'error' | 'no-source';
+type SubtitleTrackKind = 'subtitles' | 'captions';
+
+const formatTime = (seconds: number): string => {
+  if (!Number.isFinite(seconds)) {
+    return '0:00';
+  }
+
+  const totalSeconds = Math.max(0, Math.floor(seconds));
+  const hrs = Math.floor(totalSeconds / 3600);
+  const mins = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+
+  if (hrs > 0) {
+    return `${hrs}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  }
+
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+};
+
+const canUseHls = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return Hls.isSupported();
+};
+
+export function VideoPlayer({
+  title,
+  hlsSrc,
+  mp4Src,
+  poster,
+  chapters,
+  subtitleTracks,
+  statusMessages,
+  labels
+}: VideoPlayerProps): ReactElement {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const hlsRef = useRef<Hls | null>(null);
+  const [status, setStatus] = useState<PlayerStatus>('idle');
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [volume, setVolume] = useState(1);
+  const [muted, setMuted] = useState(false);
+  const [duration, setDuration] = useState(0);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [showSubtitles, setShowSubtitles] = useState(true);
+
+  useEffect(() => {
+    const videoElement = videoRef.current;
+
+    if (!videoElement) {
+      return;
+    }
+
+    if (!hlsSrc && !mp4Src) {
+      setStatus('no-source');
+      return;
+    }
+
+    setStatus('loading');
+
+    const canPlayNativeHls = videoElement.canPlayType('application/vnd.apple.mpegurl');
+
+    if (hlsSrc) {
+      if (canPlayNativeHls) {
+        videoElement.src = hlsSrc;
+        videoElement.load();
+      } else if (canUseHls()) {
+        const hls = new Hls({ enableWorker: false });
+        hlsRef.current = hls;
+        hls.attachMedia(videoElement);
+        hls.on(Hls.Events.MEDIA_ATTACHED, () => {
+          hls.loadSource(hlsSrc);
+        });
+        hls.on(Hls.Events.ERROR, (_, data) => {
+          if (data?.fatal) {
+            setStatus('error');
+          }
+        });
+      } else if (mp4Src) {
+        videoElement.src = mp4Src;
+        videoElement.load();
+      } else {
+        setStatus('error');
+      }
+    } else if (mp4Src) {
+      videoElement.src = mp4Src;
+      videoElement.load();
+    } else {
+      setStatus('no-source');
+    }
+
+    return () => {
+      if (hlsRef.current) {
+        hlsRef.current.destroy();
+        hlsRef.current = null;
+      }
+    };
+  }, [hlsSrc, mp4Src]);
+
+  useEffect(() => {
+    const videoElement = videoRef.current;
+
+    if (!videoElement) {
+      return;
+    }
+
+    const handleLoadedMetadata = () => {
+      setDuration(Number.isFinite(videoElement.duration) ? videoElement.duration : 0);
+      setStatus((current) => (current === 'loading' ? 'ready' : current));
+    };
+
+    const handlePlay = () => {
+      setIsPlaying(true);
+      setStatus('ready');
+    };
+
+    const handlePause = () => {
+      setIsPlaying(false);
+    };
+
+    const handleWaiting = () => {
+      setStatus('loading');
+    };
+
+    const handleCanPlay = () => {
+      setStatus('ready');
+    };
+
+    const handleError = () => {
+      setStatus('error');
+    };
+
+    const handleTimeUpdate = () => {
+      setCurrentTime(videoElement.currentTime);
+    };
+
+    const handleVolumeChange = () => {
+      setVolume(videoElement.volume);
+      setMuted(videoElement.muted || videoElement.volume === 0);
+    };
+
+    videoElement.addEventListener('loadedmetadata', handleLoadedMetadata);
+    videoElement.addEventListener('play', handlePlay);
+    videoElement.addEventListener('pause', handlePause);
+    videoElement.addEventListener('waiting', handleWaiting);
+    videoElement.addEventListener('canplay', handleCanPlay);
+    videoElement.addEventListener('error', handleError);
+    videoElement.addEventListener('timeupdate', handleTimeUpdate);
+    videoElement.addEventListener('volumechange', handleVolumeChange);
+
+    return () => {
+      videoElement.removeEventListener('loadedmetadata', handleLoadedMetadata);
+      videoElement.removeEventListener('play', handlePlay);
+      videoElement.removeEventListener('pause', handlePause);
+      videoElement.removeEventListener('waiting', handleWaiting);
+      videoElement.removeEventListener('canplay', handleCanPlay);
+      videoElement.removeEventListener('error', handleError);
+      videoElement.removeEventListener('timeupdate', handleTimeUpdate);
+      videoElement.removeEventListener('volumechange', handleVolumeChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const handleFullscreenChange = () => {
+      setIsFullscreen(document.fullscreenElement === videoRef.current);
+    };
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+
+    return () => {
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    const videoElement = videoRef.current;
+
+    if (!videoElement || !subtitleTracks?.length) {
+      return;
+    }
+
+    const tracks = Array.from(videoElement.textTracks);
+    tracks.forEach((track) => {
+      track.mode = showSubtitles ? 'showing' : 'disabled';
+    });
+  }, [showSubtitles, subtitleTracks]);
+
+  const statusMessage = useMemo(() => {
+    switch (status) {
+      case 'loading':
+        return statusMessages.loading;
+      case 'error':
+        return statusMessages.error;
+      case 'no-source':
+        return statusMessages.noSource;
+      default:
+        return '';
+    }
+  }, [status, statusMessages]);
+
+  const handleTogglePlay = useCallback(() => {
+    const videoElement = videoRef.current;
+
+    if (!videoElement) {
+      return;
+    }
+
+    if (videoElement.paused) {
+      void videoElement.play();
+    } else {
+      videoElement.pause();
+    }
+  }, []);
+
+  const handleSeek = useCallback((time: number) => {
+    const videoElement = videoRef.current;
+
+    if (!videoElement || !Number.isFinite(time)) {
+      return;
+    }
+
+    videoElement.currentTime = time;
+    setCurrentTime(time);
+  }, []);
+
+  const handleProgressChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const value = Number(event.target.value);
+    handleSeek(value);
+  }, [handleSeek]);
+
+  const handleVolumeChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const videoElement = videoRef.current;
+    if (!videoElement) {
+      return;
+    }
+
+    const value = Number(event.target.value);
+    videoElement.volume = value;
+    videoElement.muted = value === 0;
+    setVolume(value);
+    setMuted(value === 0);
+  }, []);
+
+  const handleToggleMute = useCallback(() => {
+    const videoElement = videoRef.current;
+
+    if (!videoElement) {
+      return;
+    }
+
+    const nextMuted = !muted;
+    videoElement.muted = nextMuted;
+    setMuted(nextMuted);
+  }, [muted]);
+
+  const handleToggleSubtitles = useCallback(() => {
+    setShowSubtitles((previous) => !previous);
+  }, []);
+
+  const handleToggleFullscreen = useCallback(() => {
+    const videoElement = videoRef.current;
+    if (!videoElement) {
+      return;
+    }
+
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    if (!document.fullscreenElement) {
+      if (typeof videoElement.requestFullscreen === 'function') {
+        void videoElement.requestFullscreen();
+      }
+      return;
+    }
+
+    if (typeof document.exitFullscreen === 'function') {
+      void document.exitFullscreen();
+    }
+  }, []);
+
+  const activeChapterId = useMemo(() => {
+    if (!chapters.length) {
+      return undefined;
+    }
+
+    const sorted = [...chapters].sort((a, b) => a.time - b.time);
+
+    for (let index = sorted.length - 1; index >= 0; index -= 1) {
+      if (currentTime >= sorted[index].time) {
+        return sorted[index].id;
+      }
+    }
+
+    return sorted[0].id;
+  }, [chapters, currentTime]);
+
+  const playbackLabel = isPlaying ? labels.pause : labels.play;
+  const muteLabel = muted ? labels.unmute : labels.mute;
+  const subtitlesLabel = showSubtitles ? labels.subtitlesOff : labels.subtitlesOn;
+  const fullscreenLabel = isFullscreen ? labels.exitFullscreen : labels.enterFullscreen;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-base-700 bg-gradient-to-br from-base-900/90 to-base-800/80 p-4 shadow-xl shadow-base-950/40">
+        <div className="flex flex-col gap-4">
+          <div className="relative overflow-hidden rounded-lg border border-base-700/80 bg-base-950/60">
+            {status === 'no-source' ? (
+              <div className="flex h-64 flex-col items-center justify-center gap-2 text-center text-sm text-base-300">
+                <p>{statusMessages.noSource}</p>
+              </div>
+            ) : (
+              <video
+                ref={videoRef}
+                data-testid="documentary-video"
+                className="aspect-video w-full rounded-lg bg-base-950"
+                controls={false}
+                poster={poster}
+                aria-label={title}
+              >
+                {mp4Src ? <source src={mp4Src} type="video/mp4" /> : null}
+                {subtitleTracks?.map((track) => (
+                  <track
+                    key={track.id}
+                    label={track.label}
+                    src={track.src}
+                    kind={track.kind ?? 'subtitles'}
+                    srcLang={track.srclang}
+                    default={track.default}
+                  />
+                ))}
+              </video>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-wrap items-center gap-2" role="group" aria-label={labels.controlsGroup}>
+              <button
+                type="button"
+                onClick={handleTogglePlay}
+                className="rounded-full bg-accent-500 px-4 py-2 text-sm font-semibold text-base-950 transition hover:bg-accent-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-300"
+                aria-label={playbackLabel}
+                aria-pressed={isPlaying}
+              >
+                {playbackLabel}
+              </button>
+              <button
+                type="button"
+                onClick={handleToggleMute}
+                className="rounded-full border border-base-600 px-4 py-2 text-sm font-semibold text-base-200 transition hover:border-accent-400 hover:text-accent-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-300"
+                aria-label={muteLabel}
+                aria-pressed={muted}
+              >
+                {muteLabel}
+              </button>
+              <button
+                type="button"
+                onClick={handleToggleSubtitles}
+                className="rounded-full border border-base-600 px-4 py-2 text-sm font-semibold text-base-200 transition hover:border-accent-400 hover:text-accent-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-300"
+                aria-label={subtitlesLabel}
+                aria-pressed={showSubtitles}
+                disabled={!subtitleTracks?.length}
+              >
+                {subtitleTracks?.length ? subtitlesLabel : labels.subtitlesUnavailable}
+              </button>
+              <button
+                type="button"
+                onClick={handleToggleFullscreen}
+                className="rounded-full border border-base-600 px-4 py-2 text-sm font-semibold text-base-200 transition hover:border-accent-400 hover:text-accent-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-300"
+                aria-label={fullscreenLabel}
+                aria-pressed={isFullscreen}
+              >
+                {fullscreenLabel}
+              </button>
+            </div>
+
+            <div className="flex flex-col gap-3" aria-live="polite">
+              {statusMessage ? (
+                <p className="text-sm text-base-300">{statusMessage}</p>
+              ) : null}
+              <label className="flex flex-col gap-1 text-xs text-base-300" htmlFor="doc-progress">
+                <span className="sr-only">{labels.progress}</span>
+                <input
+                  id="doc-progress"
+                  type="range"
+                  min={0}
+                  max={duration || 0}
+                  step={1}
+                  value={Number.isFinite(currentTime) ? currentTime : 0}
+                  onChange={handleProgressChange}
+                  aria-valuemin={0}
+                  aria-valuemax={Math.floor(duration)}
+                  aria-valuenow={Math.floor(currentTime)}
+                  aria-label={labels.progress}
+                  className="h-2 cursor-pointer appearance-none rounded-full bg-base-700 accent-accent-500"
+                />
+                <div className="flex items-center justify-between text-[0.7rem] uppercase tracking-wide text-base-400">
+                  <span>{formatTime(currentTime)}</span>
+                  <span>{formatTime(duration)}</span>
+                </div>
+              </label>
+
+              <label className="flex items-center gap-3 text-xs text-base-300" htmlFor="doc-volume">
+                <span className="sr-only">{labels.volume}</span>
+                <input
+                  id="doc-volume"
+                  type="range"
+                  min={0}
+                  max={1}
+                  step={0.05}
+                  value={volume}
+                  onChange={handleVolumeChange}
+                  aria-valuemin={0}
+                  aria-valuemax={1}
+                  aria-valuenow={Number(volume.toFixed(2))}
+                  aria-label={labels.volume}
+                  className="h-2 w-48 cursor-pointer appearance-none rounded-full bg-base-700 accent-accent-500"
+                />
+                <span className="text-[0.7rem] uppercase tracking-wide text-base-400">
+                  {labels.volumeIndicator(volume)}
+                </span>
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {chapters.length ? (
+        <div className="rounded-xl border border-base-800/70 bg-base-950/40 p-4">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-accent-200">{labels.chapterHeading}</h3>
+          <ul className="mt-3 grid gap-3 sm:grid-cols-2">
+            {chapters.map((chapter) => {
+              const isActive = chapter.id === activeChapterId;
+              const formattedTime = formatTime(chapter.time);
+              const ariaLabel = labels.getChapterAriaLabel
+                ? labels.getChapterAriaLabel(chapter, formattedTime)
+                : `${chapter.title} (${formattedTime})`;
+
+              return (
+                <li key={chapter.id}>
+                  <button
+                    type="button"
+                    onClick={() => handleSeek(chapter.time)}
+                    className={`w-full rounded-lg border px-4 py-3 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-300 ${
+                      isActive
+                        ? 'border-accent-400 bg-accent-500/10 text-accent-100'
+                        : 'border-base-700/70 bg-base-900/40 text-base-100 hover:border-accent-400 hover:text-accent-100'
+                    }`}
+                    aria-label={ariaLabel}
+                    aria-current={isActive}
+                  >
+                    <div className="flex items-center justify-between text-xs uppercase tracking-wide text-accent-300/80">
+                      <span>{formattedTime}</span>
+                      {isActive ? <span aria-label={labels.chapterCurrent}>●</span> : null}
+                    </div>
+                    <p className="mt-1 text-sm font-semibold">{chapter.title}</p>
+                    {chapter.summary ? (
+                      <p className="mt-1 text-xs text-base-300">{chapter.summary}</p>
+                    ) : null}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/documentary/doc.data.ts
+++ b/src/features/documentary/doc.data.ts
@@ -1,0 +1,55 @@
+import type { DocMeta } from './doc.schema';
+
+export const documentaryMeta: DocMeta = {
+  titleKey: 'documentary.title',
+  descriptionKey: 'documentary.description',
+  resources: [
+    {
+      id: 'timeline',
+      type: 'guide',
+      url: 'https://radio-adamowo.example.com/docs/timeline.pdf',
+      titleKey: 'documentary.resources.timeline.title',
+      descriptionKey: 'documentary.resources.timeline.description'
+    },
+    {
+      id: 'profile',
+      type: 'article',
+      url: 'https://radio-adamowo.example.com/docs/profile',
+      titleKey: 'documentary.resources.profile.title',
+      descriptionKey: 'documentary.resources.profile.description'
+    },
+    {
+      id: 'legal',
+      type: 'pdf',
+      url: 'https://radio-adamowo.example.com/docs/legal-brief.pdf',
+      titleKey: 'documentary.resources.legal.title',
+      descriptionKey: 'documentary.resources.legal.description'
+    }
+  ],
+  chapters: [
+    {
+      id: 'prologue',
+      time: 0,
+      titleKey: 'documentary.chapters.prologue.title',
+      summaryKey: 'documentary.chapters.prologue.summary'
+    },
+    {
+      id: 'escalation',
+      time: 312,
+      titleKey: 'documentary.chapters.escalation.title',
+      summaryKey: 'documentary.chapters.escalation.summary'
+    },
+    {
+      id: 'intervention',
+      time: 846,
+      titleKey: 'documentary.chapters.intervention.title',
+      summaryKey: 'documentary.chapters.intervention.summary'
+    },
+    {
+      id: 'aftermath',
+      time: 1298,
+      titleKey: 'documentary.chapters.aftermath.title',
+      summaryKey: 'documentary.chapters.aftermath.summary'
+    }
+  ]
+};

--- a/src/features/documentary/doc.schema.ts
+++ b/src/features/documentary/doc.schema.ts
@@ -1,0 +1,24 @@
+export type DocResourceType = 'pdf' | 'article' | 'audio' | 'guide' | 'video';
+
+export interface DocResource {
+  id: string;
+  type: DocResourceType;
+  url: string;
+  titleKey: string;
+  descriptionKey: string;
+}
+
+export interface DocChapter {
+  id: string;
+  time: number;
+  titleKey: string;
+  summaryKey?: string;
+}
+
+export interface DocMeta {
+  titleKey: string;
+  descriptionKey: string;
+  resources: DocResource[];
+  chapters: DocChapter[];
+  poster?: string;
+}

--- a/src/features/final-lesson/FinalLessonSection.test.tsx
+++ b/src/features/final-lesson/FinalLessonSection.test.tsx
@@ -1,0 +1,22 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { FinalLessonSection } from './FinalLessonSection';
+import { renderWithI18n } from '../../test/utils';
+
+describe('FinalLessonSection', () => {
+  test('renders summary items and resources', async () => {
+    await renderWithI18n(<FinalLessonSection />);
+
+    expect(screen.getByRole('heading', { name: 'Final Lesson' })).toBeInTheDocument();
+    expect(screen.getByText('Key takeaways')).toBeInTheDocument();
+    expect(screen.getByText('Survivor blueprint')).toBeInTheDocument();
+  });
+
+  test('shows crisis contacts with phone numbers', async () => {
+    await renderWithI18n(<FinalLessonSection />);
+
+    expect(screen.getByRole('link', { name: /Blue Line/ })).toHaveAttribute('href', 'tel:800120002');
+    expect(screen.getByRole('link', { name: /Women/ })).toHaveAttribute('href', 'tel:800120226');
+  });
+});

--- a/src/features/final-lesson/FinalLessonSection.tsx
+++ b/src/features/final-lesson/FinalLessonSection.tsx
@@ -1,0 +1,160 @@
+import type { ReactElement } from 'react';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface LessonResource {
+  id: string;
+  url: string;
+  title: string;
+  description: string;
+}
+
+interface CrisisContact {
+  id: string;
+  label: string;
+  phone: string;
+  description: string;
+}
+
+export function FinalLessonSection(): ReactElement {
+  const { t } = useTranslation();
+
+  const summaryItems = useMemo(
+    () => [
+      t('finalLesson.summary.cycle'),
+      t('finalLesson.summary.breakingSilence'),
+      t('finalLesson.summary.communityCare'),
+      t('finalLesson.summary.documentation'),
+      t('finalLesson.summary.boundaries')
+    ],
+    [t]
+  );
+
+  const resources = useMemo<LessonResource[]>(
+    () => [
+      {
+        id: 'guide-blueprint',
+        url: 'https://radio-adamowo.example.com/guides/survivor-blueprint',
+        title: t('finalLesson.resources.blueprint.title'),
+        description: t('finalLesson.resources.blueprint.description')
+      },
+      {
+        id: 'de-escalation',
+        url: 'https://radio-adamowo.example.com/guides/de-escalation',
+        title: t('finalLesson.resources.deEscalation.title'),
+        description: t('finalLesson.resources.deEscalation.description')
+      },
+      {
+        id: 'legal-kit',
+        url: 'https://radio-adamowo.example.com/guides/legal-kit',
+        title: t('finalLesson.resources.legal.title'),
+        description: t('finalLesson.resources.legal.description')
+      }
+    ],
+    [t]
+  );
+
+  const crisisContacts = useMemo<CrisisContact[]>(
+    () => [
+      {
+        id: 'niebieska-linia',
+        label: t('finalLesson.crisis.niebieska.label'),
+        phone: '800120002',
+        description: t('finalLesson.crisis.niebieska.description')
+      },
+      {
+        id: 'cpk',
+        label: t('finalLesson.crisis.cpk.label'),
+        phone: '800120226',
+        description: t('finalLesson.crisis.cpk.description')
+      }
+    ],
+    [t]
+  );
+
+  return (
+    <section
+      aria-labelledby="final-lesson-heading"
+      className="rounded-3xl border border-base-800/60 bg-gradient-to-br from-base-950/80 to-base-900/70 px-4 py-10 shadow-[0_20px_70px_rgba(8,12,31,0.5)] sm:px-6 lg:px-10"
+    >
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-10">
+        <header className="space-y-3 text-base-100">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-accent-300">
+            {t('finalLesson.sectionLabel')}
+          </p>
+          <h2 id="final-lesson-heading" className="text-3xl font-semibold text-base-50 sm:text-4xl">
+            {t('finalLesson.title')}
+          </h2>
+          <p className="max-w-3xl text-base-200">{t('finalLesson.description')}</p>
+        </header>
+
+        <div className="grid gap-8 lg:grid-cols-3">
+          <div className="lg:col-span-1">
+            <div className="rounded-2xl border border-accent-500/40 bg-accent-500/10 p-6">
+              <h3 className="text-lg font-semibold text-accent-100">{t('finalLesson.summary.title')}</h3>
+              <ul className="mt-4 space-y-3 text-sm text-base-200">
+                {summaryItems.map((item, index) => (
+                  <li key={index} className="flex items-start gap-3">
+                    <span aria-hidden="true" className="mt-1 inline-flex h-2 w-2 flex-shrink-0 rounded-full bg-accent-400" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+
+          <div className="space-y-6 lg:col-span-2">
+            <div className="rounded-2xl border border-base-800/60 bg-base-950/50 p-6">
+              <h3 className="text-lg font-semibold text-base-50">{t('finalLesson.resources.title')}</h3>
+              <p className="mt-1 text-sm text-base-300">{t('finalLesson.resources.lead')}</p>
+              <ul className="mt-4 space-y-4">
+                {resources.map((resource) => (
+                  <li key={resource.id}>
+                    <a
+                      href={resource.url}
+                      className="group block rounded-xl border border-base-800/60 bg-base-900/50 p-4 transition hover:border-accent-400 hover:text-accent-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400"
+                      target="_blank"
+                      rel="noreferrer"
+                      aria-label={`${resource.title} – ${t('finalLesson.resources.openExternal')}`}
+                    >
+                      <p className="text-base font-semibold text-base-50 group-hover:text-accent-100">{resource.title}</p>
+                      <p className="mt-1 text-sm text-base-300">{resource.description}</p>
+                      <span className="mt-2 inline-flex items-center gap-2 text-xs uppercase tracking-wide text-accent-300">
+                        {t('finalLesson.resources.visit')}
+                        <span aria-hidden="true">↗</span>
+                      </span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="rounded-2xl border border-base-800/60 bg-base-950/50 p-6">
+              <h3 className="text-lg font-semibold text-base-50">{t('finalLesson.crisis.title')}</h3>
+              <p className="mt-1 text-sm text-base-300">{t('finalLesson.crisis.description')}</p>
+              <ul className="mt-4 space-y-4">
+                {crisisContacts.map((contact) => (
+                  <li key={contact.id} className="rounded-xl border border-base-800/60 bg-base-900/60 p-4">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                      <div>
+                        <p className="text-base font-semibold text-base-50">{contact.label}</p>
+                        <p className="text-sm text-base-300">{contact.description}</p>
+                      </div>
+                      <a
+                        href={`tel:${contact.phone}`}
+                        className="inline-flex items-center justify-center rounded-full bg-accent-500 px-5 py-2 text-sm font-semibold text-base-950 transition hover:bg-accent-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-300"
+                        aria-label={t('finalLesson.crisis.callAction', { organization: contact.label, phone: contact.phone })}
+                      >
+                        {contact.phone}
+                      </a>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/footer/AppFooter.test.tsx
+++ b/src/features/footer/AppFooter.test.tsx
@@ -1,0 +1,17 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { AppFooter } from './AppFooter';
+import { renderWithI18n } from '../../test/utils';
+
+describe('AppFooter', () => {
+  test('renders footer navigation and copyright', async () => {
+    await renderWithI18n(<AppFooter />);
+
+    expect(screen.getByRole('link', { name: 'Documentation' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Privacy & cookies' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Methodology & sources' })).toBeInTheDocument();
+    expect(screen.getByText('© 2025 Radio Adamowo')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to top' })).toHaveAttribute('href', '#main-content');
+  });
+});

--- a/src/features/footer/AppFooter.tsx
+++ b/src/features/footer/AppFooter.tsx
@@ -1,0 +1,65 @@
+import type { ReactElement } from 'react';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface FooterLink {
+  id: string;
+  href: string;
+  label: string;
+}
+
+export function AppFooter(): ReactElement {
+  const { t } = useTranslation();
+
+  const links = useMemo<FooterLink[]>(
+    () => [
+      {
+        id: 'documentation',
+        href: '/docs',
+        label: t('footer.links.documentation')
+      },
+      {
+        id: 'privacy',
+        href: '/privacy',
+        label: t('footer.links.privacy')
+      },
+      {
+        id: 'methodology',
+        href: '/methodology',
+        label: t('footer.links.methodology')
+      }
+    ],
+    [t]
+  );
+
+  return (
+    <footer className="border-t border-base-900/80 bg-base-950/80 text-base-300">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10 md:flex-row md:items-center md:justify-between md:px-6">
+        <nav aria-label={t('footer.navigation')} className="flex-1">
+          <ul className="flex flex-col gap-3 sm:flex-row sm:gap-6">
+            {links.map((link) => (
+              <li key={link.id}>
+                <a
+                  href={link.href}
+                  className="text-sm font-medium text-base-200 transition hover:text-accent-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400"
+                >
+                  {link.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        <div className="flex flex-col gap-3 text-sm text-base-400 md:items-end">
+          <a
+            href="#main-content"
+            className="inline-flex items-center gap-2 self-start rounded-full border border-accent-500/40 bg-accent-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-accent-200 transition hover:bg-accent-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 md:self-auto"
+          >
+            {t('footer.backToTop')}
+          </a>
+          <p className="text-xs text-base-500">{t('footer.rights')}</p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -133,5 +133,133 @@
         }
       }
     }
+  },
+  "documentary": {
+    "sectionLabel": "Documentary",
+    "title": "The Adamowo Case: Autopsy of a Family War",
+    "description": "An investigative dive into the power structures that tore the Adamowo family apart — and the lessons that help communities interrupt violence.",
+    "player": {
+      "controlsGroup": "Video controls",
+      "play": "Play video",
+      "pause": "Pause video",
+      "mute": "Mute",
+      "unmute": "Unmute",
+      "subtitlesOn": "Enable subtitles",
+      "subtitlesOff": "Disable subtitles",
+      "subtitlesUnavailable": "Subtitles unavailable",
+      "enterFullscreen": "Enter fullscreen",
+      "exitFullscreen": "Exit fullscreen",
+      "progress": "Seek video",
+      "volume": "Adjust volume",
+      "volumeIndicator": "Volume: {{value}}%",
+      "chaptersHeading": "Chapters",
+      "chapterCurrent": "Current chapter",
+      "chapterAriaLabel": "{{title}} ({{time}})",
+      "status": {
+        "loading": "Loading documentary…",
+        "error": "We could not load the documentary stream.",
+        "noSource": "The video source is unavailable. Please provide an HLS or MP4 URL.",
+        "configurationHint": "Configure environment variables VITE_DOC_VIDEO_HLS or VITE_DOC_VIDEO_MP4 to publish the stream."
+      }
+    },
+    "resources": {
+      "heading": "Companion materials",
+      "description": "Downloadable dossiers and reporting to continue the investigation.",
+      "timeline": {
+        "title": "Case timeline",
+        "description": "Chronological report of escalation, interventions and court milestones."
+      },
+      "profile": {
+        "title": "Family profiles",
+        "description": "Portraits of the key actors and the networks around them."
+      },
+      "legal": {
+        "title": "Legal brief",
+        "description": "Summary of proceedings, evidence handling and jurisprudence."
+      }
+    },
+    "resourceTypes": {
+      "pdf": "PDF dossier",
+      "article": "Article",
+      "audio": "Audio",
+      "guide": "Guide",
+      "video": "Video"
+    },
+    "subtitles": {
+      "primaryLabel": "Polish subtitles",
+      "primaryCode": "pl"
+    },
+    "chapters": {
+      "prologue": {
+        "title": "Prologue: Break in the static",
+        "summary": "Conflicting testimonies surface during a neighbour's complaint."
+      },
+      "escalation": {
+        "title": "Escalation spiral",
+        "summary": "Isolation, financial control and coercive threats intensify."
+      },
+      "intervention": {
+        "title": "Intervention night",
+        "summary": "Community radio and local services coordinate a high-risk exit."
+      },
+      "aftermath": {
+        "title": "Aftermath and repair",
+        "summary": "Survivors rebuild support networks while courts deliberate."
+      }
+    }
+  },
+  "finalLesson": {
+    "sectionLabel": "Final lesson",
+    "title": "Final Lesson",
+    "description": "What to carry forward from the Adamowo case and where to find help right now.",
+    "summary": {
+      "title": "Key takeaways",
+      "cycle": "Abuse is systemic: patterns repeat unless the power balance changes.",
+      "breakingSilence": "Speaking up is safer with a plan — rehearse disclosure with allies.",
+      "communityCare": "Community media can document, witness and prevent isolation.",
+      "documentation": "Evidence logs protect survivors when narratives are weaponised.",
+      "boundaries": "Setting firm boundaries is a right, never an overreaction."
+    },
+    "resources": {
+      "title": "Support resources",
+      "lead": "Toolkits, guides and contacts to extend the work beyond the documentary.",
+      "visit": "Visit resource",
+      "openExternal": "Opens in a new window",
+      "blueprint": {
+        "title": "Survivor blueprint",
+        "description": "Scenario planning workbook with safety checklists and exit mapping."
+      },
+      "deEscalation": {
+        "title": "De-escalation playbook",
+        "description": "Micro-interventions and scripts for friends, neighbours and coworkers."
+      },
+      "legal": {
+        "title": "Legal response kit",
+        "description": "Guidance on documenting evidence and seeking pro-bono representation."
+      }
+    },
+    "crisis": {
+      "title": "Crisis contacts (Poland)",
+      "description": "If you or someone you know is in immediate danger, reach out now.",
+      "niebieska": {
+        "label": "Blue Line – National emergency helpline",
+        "description": "24/7 psychological and legal help for survivors of violence."
+      },
+      "cpk": {
+        "label": "Women's Rights Centre",
+        "description": "Legal advice, shelters and psychological care for women experiencing abuse."
+      },
+      "callAction": "Call {{organization}} at {{phone}}"
+    }
+  },
+  "footer": {
+    "navigation": "Footer navigation",
+    "links": {
+      "documentation": "Documentation",
+      "privacy": "Privacy & cookies",
+      "methodology": "Methodology & sources"
+    },
+    "backToTop": "Back to top",
+    "rights": "© 2025 Radio Adamowo"
   }
 }

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -133,5 +133,133 @@
         }
       }
     }
+  },
+  "documentary": {
+    "sectionLabel": "Documentaire",
+    "title": "De zaak Adamowo: autopsie van een familieoorlog",
+    "description": "Een onderzoek naar de machtsstructuren die het gezin uit Adamowo verbraken — en naar de strategieën waarmee gemeenschappen geweld kunnen doorbreken.",
+    "player": {
+      "controlsGroup": "Videobediening",
+      "play": "Video afspelen",
+      "pause": "Video pauzeren",
+      "mute": "Dempen",
+      "unmute": "Geluid aan",
+      "subtitlesOn": "Ondertiteling inschakelen",
+      "subtitlesOff": "Ondertiteling uitschakelen",
+      "subtitlesUnavailable": "Ondertiteling niet beschikbaar",
+      "enterFullscreen": "Volledig scherm",
+      "exitFullscreen": "Volledig scherm sluiten",
+      "progress": "Zoek in video",
+      "volume": "Volume aanpassen",
+      "volumeIndicator": "Volume: {{value}}%",
+      "chaptersHeading": "Hoofdstukken",
+      "chapterCurrent": "Huidig hoofdstuk",
+      "chapterAriaLabel": "{{title}} ({{time}})",
+      "status": {
+        "loading": "Documentaire laden…",
+        "error": "De videostream kon niet worden geladen.",
+        "noSource": "Geen videobron gevonden. Voeg een HLS- of MP4-adres toe.",
+        "configurationHint": "Stel de variabelen VITE_DOC_VIDEO_HLS of VITE_DOC_VIDEO_MP4 in om de stream te publiceren."
+      }
+    },
+    "resources": {
+      "heading": "Aanvullende materialen",
+      "description": "Dossiers en artikelen om het onderzoek te verdiepen.",
+      "timeline": {
+        "title": "Tijdlijn van de zaak",
+        "description": "Chronologisch overzicht van escalatie, interventies en gerechtelijke stappen."
+      },
+      "profile": {
+        "title": "Profielen van het gezin",
+        "description": "Portretten van de hoofdrolspelers en hun netwerken."
+      },
+      "legal": {
+        "title": "Juridische samenvatting",
+        "description": "Overzicht van procedures, bewijsvoering en jurisprudentie."
+      }
+    },
+    "resourceTypes": {
+      "pdf": "PDF-dossier",
+      "article": "Artikel",
+      "audio": "Audio",
+      "guide": "Gids",
+      "video": "Video"
+    },
+    "subtitles": {
+      "primaryLabel": "Poolse ondertiteling",
+      "primaryCode": "pl"
+    },
+    "chapters": {
+      "prologue": {
+        "title": "Proloog: ruis doorbreekt de stilte",
+        "summary": "Tegenstrijdige verklaringen komen boven tijdens een buurtmelding."
+      },
+      "escalation": {
+        "title": "Spiraal van escalatie",
+        "summary": "Isolatie, financiële controle en dwang nemen toe."
+      },
+      "intervention": {
+        "title": "Nacht van de interventie",
+        "summary": "Communityradio en hulpdiensten organiseren een risicovolle uitweg."
+      },
+      "aftermath": {
+        "title": "Nasleep en herstel",
+        "summary": "Overlevenden bouwen steun opnieuw op terwijl de rechtbank oordeelt."
+      }
+    }
+  },
+  "finalLesson": {
+    "sectionLabel": "Laatste les",
+    "title": "Laatste les",
+    "description": "Wat we meenemen uit de zaak Adamowo en waar directe hulp te vinden is.",
+    "summary": {
+      "title": "Belangrijkste inzichten",
+      "cycle": "Geweld is structureel: patronen keren terug tenzij de machtsbalans verschuift.",
+      "breakingSilence": "Doorbreek het zwijgen met een plan en vertrouwenspersonen.",
+      "communityCare": "Lokale media kunnen documenteren, getuigen en isolatie tegengaan.",
+      "documentation": "Bewijslogboeken beschermen wanneer verhalen tegen slachtoffers worden gebruikt.",
+      "boundaries": "Grenzen stellen is een recht, geen overreactie."
+    },
+    "resources": {
+      "title": "Hulpmiddelen",
+      "lead": "Toolkits, gidsen en contacten om verder te werken na de documentaire.",
+      "visit": "Ga naar hulpmiddel",
+      "openExternal": "Opent in een nieuw venster",
+      "blueprint": {
+        "title": "Overlevingsplan",
+        "description": "Scenario-oefeningen met veiligheidschecklists en exitplanning."
+      },
+      "deEscalation": {
+        "title": "De-escalatiehandleiding",
+        "description": "Micro-interventies en scripts voor vrienden, buren en collega's."
+      },
+      "legal": {
+        "title": "Juridische toolkit",
+        "description": "Advies over documentatie en het vinden van pro-deo vertegenwoordiging."
+      }
+    },
+    "crisis": {
+      "title": "Crisisnummers (Polen)",
+      "description": "Als jij of iemand in je omgeving direct gevaar loopt, bel nu.",
+      "niebieska": {
+        "label": "Niebieska Linia – landelijk hulplijn",
+        "description": "24/7 psychologische en juridische ondersteuning voor slachtoffers van geweld."
+      },
+      "cpk": {
+        "label": "Centrum voor Vrouwenrechten",
+        "description": "Juridisch advies, opvang en psychologische hulp voor vrouwen."
+      },
+      "callAction": "Bel {{organization}} op {{phone}}"
+    }
+  },
+  "footer": {
+    "navigation": "Voettekstnavigatie",
+    "links": {
+      "documentation": "Documentatie",
+      "privacy": "Privacy en cookies",
+      "methodology": "Methodologie en bronnen"
+    },
+    "backToTop": "Terug naar boven",
+    "rights": "© 2025 Radio Adamowo"
   }
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -133,5 +133,133 @@
         }
       }
     }
+  },
+  "documentary": {
+    "sectionLabel": "Materiał dokumentalny",
+    "title": "Sprawa z Adamowa: Autopsja rodzinnej wojny",
+    "description": "Reporterskie śledztwo w mechanizmy władzy, które rozdarły rodzinę z Adamowa — i praktyki, które pomagają przerwać przemoc.",
+    "player": {
+      "controlsGroup": "Sterowanie odtwarzaczem",
+      "play": "Odtwórz wideo",
+      "pause": "Wstrzymaj wideo",
+      "mute": "Wycisz",
+      "unmute": "Włącz dźwięk",
+      "subtitlesOn": "Włącz napisy",
+      "subtitlesOff": "Wyłącz napisy",
+      "subtitlesUnavailable": "Napisy niedostępne",
+      "enterFullscreen": "Pełny ekran",
+      "exitFullscreen": "Zamknij pełny ekran",
+      "progress": "Przesuń wideo",
+      "volume": "Zmień głośność",
+      "volumeIndicator": "Głośność: {{value}}%",
+      "chaptersHeading": "Rozdziały",
+      "chapterCurrent": "Obecny rozdział",
+      "chapterAriaLabel": "{{title}} ({{time}})",
+      "status": {
+        "loading": "Ładowanie materiału…",
+        "error": "Nie udało się wczytać strumienia dokumentu.",
+        "noSource": "Brak źródła wideo. Dodaj adres HLS lub MP4.",
+        "configurationHint": "Skonfiguruj zmienne VITE_DOC_VIDEO_HLS lub VITE_DOC_VIDEO_MP4, aby udostępnić transmisję."
+      }
+    },
+    "resources": {
+      "heading": "Materiały towarzyszące",
+      "description": "Pobierz opracowania i artykuły pogłębiające dochodzenie.",
+      "timeline": {
+        "title": "Oś czasu sprawy",
+        "description": "Chronologiczny opis eskalacji, interwencji i etapów sądowych."
+      },
+      "profile": {
+        "title": "Portrety rodziny",
+        "description": "Sylwetki kluczowych osób i ich sieci wsparcia."
+      },
+      "legal": {
+        "title": "Brief prawny",
+        "description": "Podsumowanie postępowań, dowodów i orzecznictwa."
+      }
+    },
+    "resourceTypes": {
+      "pdf": "Plik PDF",
+      "article": "Artykuł",
+      "audio": "Audio",
+      "guide": "Poradnik",
+      "video": "Wideo"
+    },
+    "subtitles": {
+      "primaryLabel": "Napisy polskie",
+      "primaryCode": "pl"
+    },
+    "chapters": {
+      "prologue": {
+        "title": "Prolog: zakłócenie ciszy",
+        "summary": "Podczas sąsiedzkiej skargi wypływają sprzeczne świadectwa."
+      },
+      "escalation": {
+        "title": "Spirala eskalacji",
+        "summary": "Nasilają się izolacja, kontrola finansowa i groźby."
+      },
+      "intervention": {
+        "title": "Noc interwencji",
+        "summary": "Radio społeczne i służby koordynują wyjście wysokiego ryzyka."
+      },
+      "aftermath": {
+        "title": "Skutki i odbudowa",
+        "summary": "Ocalałe osoby odbudowują sieci wsparcia, a sąd waży dowody."
+      }
+    }
+  },
+  "finalLesson": {
+    "sectionLabel": "Ostateczna lekcja",
+    "title": "Ostateczna Lekcja",
+    "description": "Co wynosimy ze sprawy Adamowo i gdzie szukać pomocy tu i teraz.",
+    "summary": {
+      "title": "Najważniejsze wnioski",
+      "cycle": "Przemoc jest systemem — wzorzec wróci, jeśli nie zmienimy układu sił.",
+      "breakingSilence": "Mówienie głośno jest bezpieczniejsze z planem i zaufanymi osobami.",
+      "communityCare": "Media społecznościowe mogą dokumentować, świadkować i rozbrajać izolację.",
+      "documentation": "Archiwizacja dowodów chroni, gdy narracje są używane przeciw ocalałym.",
+      "boundaries": "Stawianie granic to prawo, a nie przesada."
+    },
+    "resources": {
+      "title": "Zasoby pomocowe",
+      "lead": "Zestawy narzędzi, poradniki i kontakty, które rozszerzają pracę poza dokumentem.",
+      "visit": "Przejdź do zasobu",
+      "openExternal": "Otwiera się w nowym oknie",
+      "blueprint": {
+        "title": "Plan bezpieczeństwa",
+        "description": "Ćwiczenia scenariuszowe z checklistą bezpieczeństwa i mapą wyjścia."
+      },
+      "deEscalation": {
+        "title": "Podręcznik deeskalacji",
+        "description": "Mikrointerwencje i podpowiedzi dla przyjaciół, sąsiadów i współpracowników."
+      },
+      "legal": {
+        "title": "Zestaw prawny",
+        "description": "Instrukcje dokumentowania i pozyskiwania reprezentacji pro bono."
+      }
+    },
+    "crisis": {
+      "title": "Kontakty kryzysowe (Polska)",
+      "description": "Jeśli ty lub ktoś bliski jest w zagrożeniu, skontaktuj się natychmiast.",
+      "niebieska": {
+        "label": "Niebieska Linia – telefon zaufania",
+        "description": "Całodobowe wsparcie psychologiczne i prawne dla osób doświadczających przemocy."
+      },
+      "cpk": {
+        "label": "Centrum Praw Kobiet",
+        "description": "Porady prawne, schronienie i opieka psychologiczna dla kobiet."
+      },
+      "callAction": "Zadzwoń do {{organization}} pod numer {{phone}}"
+    }
+  },
+  "footer": {
+    "navigation": "Nawigacja w stopce",
+    "links": {
+      "documentation": "Dokumentacja",
+      "privacy": "Prywatność i cookies",
+      "methodology": "Metodologia i źródła"
+    },
+    "backToTop": "Do góry",
+    "rights": "© 2025 Radio Adamowo"
   }
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,8 @@
 import type { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { DocumentarySection } from '../features/documentary/DocumentarySection';
+import { FinalLessonSection } from '../features/final-lesson/FinalLessonSection';
 import { ViolenceLoopSection } from '../features/violence-loop/ViolenceLoopSection';
 
 export default function Home(): ReactElement {
@@ -13,6 +15,8 @@ export default function Home(): ReactElement {
         <p className="max-w-2xl text-base-200">{t('pages.home.lead')}</p>
       </section>
 
+      <DocumentarySection />
+      <FinalLessonSection />
       <ViolenceLoopSection />
     </div>
   );

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react';
+import type { RenderOptions } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import i18next from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+
+import en from '../i18n/en.json';
+
+export async function renderWithI18n(
+  ui: ReactElement,
+  options?: RenderOptions
+) {
+  const i18nInstance = i18next.createInstance();
+  await i18nInstance.use(initReactI18next).init({
+    lng: 'en',
+    fallbackLng: 'en',
+    resources: {
+      en: { translation: en }
+    }
+  });
+
+  return render(<I18nextProvider i18n={i18nInstance}>{ui}</I18nextProvider>, options);
+}

--- a/src/types/hls.d.ts
+++ b/src/types/hls.d.ts
@@ -1,0 +1,24 @@
+declare module 'hls.js' {
+  export default class Hls {
+    static Events: {
+      MEDIA_ATTACHED: string;
+      MANIFEST_PARSED: string;
+      LEVEL_LOADED: string;
+      ERROR: string;
+    };
+    static ErrorTypes: {
+      NETWORK_ERROR: string;
+      MEDIA_ERROR: string;
+      OTHER_ERROR: string;
+    };
+    static isSupported(): boolean;
+    constructor(config?: unknown);
+    attachMedia(media: HTMLMediaElement): void;
+    loadSource(source: string): void;
+    on(event: string, handler: (event: string, data: any) => void): void;
+    stopLoad(): void;
+    detachMedia(): void;
+    recoverMediaError(): void;
+    destroy(): void;
+  }
+}


### PR DESCRIPTION
## Summary
- add a documentary section with reusable metadata, adaptive HLS/MP4 player, and localized supporting materials
- introduce the final lesson wrap-up and footer navigation while wiring them into the home layout and translations
- cover the new player and content sections with Vitest suites and shared i18n test utilities

## Testing
- `pnpm lint` *(fails: corepack cannot download pnpm in the sandbox)*
- `npm run lint` *(fails: existing ESLint configuration reports global `JSX`/Vitest symbol issues outside the change scope)*
- `npm run test -- --run` *(fails: Vitest environment is missing the optional `jsdom` dependency in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68db1bfab8688322b5280b9e1670d673