### PR TITLE
PR-11: Standardize layout containers and lazy routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Aplikacja uruchomi się pod adresem `http://localhost:5173`.
 ## Testy
 Testy jednostkowe znajdują się w katalogu obok komponentów lub w `src/test`.
 
+## Utrzymanie jakości Lighthouse
+- Uruchamiaj `pnpm build && pnpm preview` przed pomiarem, aby testować zoptymalizowany bundle.
+- Sprawdzaj `pnpm lint`, `pnpm test` oraz podstawowe scenariusze e2e po każdej zmianie nawigacji, dostępności lub layoutu.
+- Na stronach startowych i kluczowych podstronach utrzymuj wyniki Lighthouse: Performance ≥ 85, Accessibility ≥ 90, Best Practices ≥ 90, SEO ≥ 90.
+- Upewnij się, że wszystkie obrazy i multimedia mają atrybuty `loading="lazy"`, zdefiniowane wymiary oraz alternatywne teksty.
+- Weryfikuj dostępność klawiaturą: skip link, fokusy i brak pułapek w menu mobilnym, modalach i zakładkach.
+- Respektuj `prefers-reduced-motion`, ograniczając animacje i opóźnioną inicjalizację ciężkich efektów do interakcji użytkownika.
+
 ## Audycje Analityczne
 - Kontener funkcjonalności znajduje się w `src/features/analysis-archive`.
 - Dane lokalne i schemat typów są w plikach `data.local.json` oraz `data.schema.ts`.

--- a/src/app.css
+++ b/src/app.css
@@ -6,20 +6,46 @@
   color-scheme: dark light;
 }
 
-html {
-  min-height: 100%;
-  background-color: theme('colors.base.950');
+@layer base {
+  html {
+    min-height: 100%;
+    background-color: theme('colors.base.950');
+  }
+
+  body {
+    min-height: 100vh;
+  }
+
+  a {
+    @apply text-accent-400 transition-colors hover:text-accent-500;
+  }
+
+  :focus-visible {
+    @apply outline-none ring-2 ring-accent-400 ring-offset-2 ring-offset-base-950;
+  }
+
+  .skip-link {
+    @apply pointer-events-auto focus-visible:ring-offset-base-950;
+  }
 }
 
-body {
-  min-height: 100vh;
+@layer components {
+  .container-responsive {
+    @apply mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8;
+  }
+
+  .touch-target {
+    @apply min-h-[44px] min-w-[44px];
+  }
 }
 
-a {
-  @apply text-accent-400 hover:text-accent-500 focus:outline-none focus-visible:shadow-focus;
-}
-
-button,
-[role='button'] {
-  @apply focus:outline-none focus-visible:shadow-focus;
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -11,14 +11,14 @@ export function AppShell(): JSX.Element {
     <div className="min-h-screen bg-base-950 text-base-100">
       <a
         href="#main-content"
-        className="skip-link absolute left-4 top-4 z-50 -translate-y-16 rounded-full bg-accent-500 px-4 py-2 text-sm font-semibold text-base-950 opacity-0 shadow-lg transition focus:translate-y-0 focus:opacity-100 focus:outline-none focus-visible:shadow-focus"
+        className="skip-link absolute left-4 top-4 z-50 -translate-y-16 rounded-full bg-accent-500 px-4 py-2 text-sm font-semibold text-base-950 opacity-0 shadow-lg transition focus-visible:translate-y-0 focus-visible:opacity-100"
       >
         {t('header.skipToContent')}
       </a>
       <Header />
       <main
         id="main-content"
-        className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-10 px-4 pb-16 pt-10 md:px-6"
+        className="container-responsive flex flex-1 flex-col gap-10 pb-16 pt-24"
         tabIndex={-1}
       >
         <Outlet />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
-import { AnimatePresence, motion } from 'framer-motion';
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -20,6 +20,21 @@ export function Header(): JSX.Element {
   const [menuOpen, setMenuOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const menuId = useId();
+  const reduceMotion = useReducedMotion();
+  const prefetchedRef = useRef(new Set<string>());
+
+  const prefetchers = useMemo(
+    () => ({
+      '/live': () => import('../pages/Live'),
+      '/violence-loop': () => import('../pages/ViolenceLoop'),
+      '/shows': () => import('../pages/Shows'),
+      '/guides': () => import('../pages/Guides'),
+      '/lab': () => import('../pages/Lab'),
+      '/community': () => import('../pages/Community'),
+      '/analysis': () => import('../features/analysis-archive/AnalysisPage')
+    }),
+    []
+  );
 
   const closeMenu = useCallback(() => setMenuOpen(false), []);
 
@@ -71,7 +86,7 @@ export function Header(): JSX.Element {
               to={item.to}
               className={({ isActive }) =>
                 clsx(
-                  'relative inline-flex items-center justify-center text-base font-medium transition-colors',
+                  'relative inline-flex touch-target items-center justify-center rounded-full px-3 py-2 text-base font-medium transition-colors',
                   variant === 'desktop'
                     ? 'text-base-200 hover:text-base-50'
                     : 'text-base-50 hover:text-accent-300',
@@ -79,6 +94,18 @@ export function Header(): JSX.Element {
                 )
               }
               onClick={variant === 'mobile' ? closeMenu : undefined}
+              onFocus={() => {
+                if (!prefetchedRef.current.has(item.to)) {
+                  prefetchedRef.current.add(item.to);
+                  void prefetchers[item.to]?.();
+                }
+              }}
+              onMouseEnter={() => {
+                if (!prefetchedRef.current.has(item.to)) {
+                  prefetchedRef.current.add(item.to);
+                  void prefetchers[item.to]?.();
+                }
+              }}
             >
               <span>{t(item.labelKey)}</span>
             </NavLink>
@@ -90,13 +117,17 @@ export function Header(): JSX.Element {
   const mobileMenuLabel = menuOpen ? t('header.closeMenu') : t('header.openMenu');
 
   return (
-    <header className="sticky top-0 z-40 border-b border-base-800/70 bg-base-950/80 text-base-50 shadow-[0_1px_0_rgba(12,17,37,0.8)] backdrop-blur supports-[backdrop-filter]:bg-base-950/60">
-      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 md:px-6">
+    <header
+      role="navigation"
+      aria-label={t('header.navigation')}
+      className="sticky top-0 z-40 border-b border-base-800/70 bg-base-950/80 text-base-50 shadow-[0_1px_0_rgba(12,17,37,0.8)] backdrop-blur supports-[backdrop-filter]:bg-base-950/60"
+    >
+      <div className="container-responsive flex items-center justify-between gap-4 py-4">
         <NavLink to="/" className="group flex items-center gap-3" aria-label={t('header.home')}>
           <motion.span
             className="rounded-full bg-base-900/70 p-2 transition group-hover:bg-base-850 group-focus-visible:bg-base-850"
-            whileHover={{ scale: 1.02 }}
-            whileFocus={{ scale: 1.02 }}
+            whileHover={reduceMotion ? undefined : { scale: 1.02 }}
+            whileFocus={reduceMotion ? undefined : { scale: 1.02 }}
           >
             <LogoGlasses className="h-9 w-auto" />
           </motion.span>
@@ -116,7 +147,7 @@ export function Header(): JSX.Element {
           <ThemeSwitch />
           <button
             type="button"
-            className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-base-700 bg-base-900/80 text-base-100 transition hover:border-accent-500 hover:text-accent-200 focus-visible:shadow-focus md:hidden"
+            className="touch-target inline-flex h-11 w-11 items-center justify-center rounded-full border border-base-700 bg-base-900/80 text-base-100 transition hover:border-accent-500 hover:text-accent-200 md:hidden"
             aria-controls={menuId}
             aria-expanded={menuOpen}
             onClick={toggleMenu}
@@ -125,8 +156,8 @@ export function Header(): JSX.Element {
             <span className="sr-only">{mobileMenuLabel}</span>
             <motion.span
               className="flex flex-col items-center justify-center gap-1.5"
-              animate={{ rotate: menuOpen ? 90 : 0 }}
-              transition={{ type: 'spring', stiffness: 260, damping: 28 }}
+              animate={reduceMotion ? undefined : { rotate: menuOpen ? 90 : 0 }}
+              transition={reduceMotion ? undefined : { type: 'spring', stiffness: 260, damping: 28 }}
             >
               <span
                 className={clsx(
@@ -158,7 +189,7 @@ export function Header(): JSX.Element {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            transition={{ duration: 0.18 }}
+            transition={reduceMotion ? { duration: 0 } : { duration: 0.18 }}
           >
             <motion.div
               ref={panelRef}
@@ -166,10 +197,10 @@ export function Header(): JSX.Element {
               aria-modal="true"
               aria-label={t('header.navigation')}
               className="space-y-6 border-t border-base-800 bg-base-900/95 px-4 pb-8 pt-6 text-base-100 shadow-lg"
-              initial={{ y: -12, opacity: 0 }}
-              animate={{ y: 0, opacity: 1 }}
-              exit={{ y: -12, opacity: 0 }}
-              transition={{ duration: 0.2 }}
+              initial={reduceMotion ? { opacity: 1 } : { y: -12, opacity: 0 }}
+              animate={reduceMotion ? { opacity: 1 } : { y: 0, opacity: 1 }}
+              exit={reduceMotion ? { opacity: 0 } : { y: -12, opacity: 0 }}
+              transition={reduceMotion ? { duration: 0 } : { duration: 0.2 }}
             >
               {renderNavLinks('mobile')}
             </motion.div>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,14 +1,16 @@
+import { lazy } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 
 import { AppShell } from './components/AppShell';
-import Community from './pages/Community';
-import Guides from './pages/Guides';
-import Home from './pages/Home';
-import Lab from './pages/Lab';
-import Live from './pages/Live';
-import Shows from './pages/Shows';
-import ViolenceLoop from './pages/ViolenceLoop';
-import AnalysisPage from './features/analysis-archive/AnalysisPage';
+
+const Home = lazy(() => import('./pages/Home'));
+const Live = lazy(() => import('./pages/Live'));
+const ViolenceLoop = lazy(() => import('./pages/ViolenceLoop'));
+const Shows = lazy(() => import('./pages/Shows'));
+const AnalysisPage = lazy(() => import('./features/analysis-archive/AnalysisPage'));
+const Guides = lazy(() => import('./pages/Guides'));
+const Lab = lazy(() => import('./pages/Lab'));
+const Community = lazy(() => import('./pages/Community'));
 
 export const router = createBrowserRouter([
   {


### PR DESCRIPTION
## Summary
- add global focus-visible rings, shared responsive container utility and reduced-motion override
- update the sticky header with lazy route prefetching, motion fallbacks and larger touch targets
- extend the hero player with lazy artwork decoding, motion preference handling and revised controls spacing
- lazy-load page routes for secondary sections and document the Lighthouse QA checklist

## Testing
- `pnpm lint` *(fails: blocked from downloading pnpm due to registry proxy 403)*
- `pnpm test` *(fails: blocked from downloading pnpm due to registry proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68db1f47dc7083228e015e9eddeafb6e