### PR TITLE
feat: add interactive community zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Aplikacja uruchomi się pod adresem `http://localhost:5173`.
 - Dostępne przełączniki motywu i języka.
 - Translacje dla PL/NL/EN z autodetekcją języka przeglądarki.
 
+## Zasady treści i prywatność (Strefa Interaktywna)
+- Publikowane wypowiedzi i wpisy dziennika są przechowywane wyłącznie lokalnie w `localStorage` przeglądarki użytkownika.
+- Zakaz udostępniania danych identyfikujących (imiona, adresy, dane prawne) – moderator działa lokalnie po stronie użytkownika.
+- Symulator rozmowy działa offline, bez połączeń sieciowych i zapisuje historię wyłącznie w aktualnej sesji.
+
+### Eksport danych użytkownika
+- Dane z Dziennika Czerwonych Flag można wyeksportować do pliku JSON bezpośrednio z interfejsu aplikacji.
+- Wyeksportowany plik zawiera pełną listę wpisów przechowywanych lokalnie; kopiowanie lub usuwanie danych odbywa się po stronie użytkownika.
+
 ### Kocioł Wiedźmy: Pętla Przemocy
 - Animowany diagram nieskończoności wykorzystuje pętlę o długości ~14 s z możliwością pauzy, resetu oraz ręcznego wyboru fazy.
 - Przy włączonym systemowym `prefers-reduced-motion` animacja startuje w stanie pauzy, a w UI dostępny jest przełącznik "Ogranicz animacje".

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef, type JSX } from 'react';
+import clsx from 'clsx';
+
+export type ConfirmDialogProps = {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel
+}: ConfirmDialogProps): JSX.Element | null {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      cancelRef.current?.focus();
+    }
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      role="presentation"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-base-950/70 backdrop-blur"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        aria-describedby={description ? 'confirm-dialog-description' : undefined}
+        className="mx-4 w-full max-w-md rounded-xl bg-base-900 p-6 shadow-xl"
+      >
+        <h2 id="confirm-dialog-title" className="text-lg font-semibold text-base-50">
+          {title}
+        </h2>
+        {description ? (
+          <p id="confirm-dialog-description" className="mt-2 text-sm text-base-200">
+            {description}
+          </p>
+        ) : null}
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+            className={clsx(
+              'rounded-md border border-base-700 px-4 py-2 text-sm font-medium text-base-100',
+              'transition-colors hover:bg-base-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950'
+            )}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={clsx(
+              'rounded-md bg-accent-500 px-4 py-2 text-sm font-semibold text-base-950 shadow-sm',
+              'transition-colors hover:bg-accent-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-300 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950'
+            )}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TabNav.test.tsx
+++ b/src/components/TabNav.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useState } from 'react';
+
+import { TabNav, type TabDefinition } from './TabNav';
+
+function TabNavWrapper({ tabs }: { tabs: TabDefinition[] }) {
+  const [active, setActive] = useState(tabs[0]!.id);
+  return <TabNav tabs={tabs} activeTab={active} onChange={setActive} ariaLabel="Test tabs" />;
+}
+
+describe('TabNav', () => {
+  const tabs: TabDefinition[] = [
+    { id: 'one', label: 'One', panelId: 'panel-one' },
+    { id: 'two', label: 'Two', panelId: 'panel-two' }
+  ];
+
+  it('marks the active tab with aria-selected', () => {
+    render(<TabNavWrapper tabs={tabs} />);
+
+    const firstTab = screen.getByRole('tab', { name: 'One' });
+    const secondTab = screen.getByRole('tab', { name: 'Two' });
+    expect(firstTab).toHaveAttribute('aria-selected', 'true');
+    expect(secondTab).toHaveAttribute('aria-selected', 'false');
+
+    fireEvent.click(secondTab);
+    expect(firstTab).toHaveAttribute('aria-selected', 'false');
+    expect(secondTab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('navigates with arrow keys', () => {
+    render(<TabNavWrapper tabs={tabs} />);
+    const firstTab = screen.getByRole('tab', { name: 'One' });
+    const secondTab = screen.getByRole('tab', { name: 'Two' });
+
+    firstTab.focus();
+    fireEvent.keyDown(firstTab, { key: 'ArrowRight' });
+
+    expect(secondTab).toHaveFocus();
+    expect(secondTab).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/src/components/TabNav.tsx
+++ b/src/components/TabNav.tsx
@@ -1,0 +1,82 @@
+import { KeyboardEvent, type JSX } from 'react';
+import clsx from 'clsx';
+
+export type TabDefinition = {
+  id: string;
+  label: string;
+  panelId: string;
+};
+
+export type TabNavProps = {
+  tabs: TabDefinition[];
+  activeTab: string;
+  onChange: (id: string) => void;
+  className?: string;
+  ariaLabel?: string;
+};
+
+export function TabNav({ tabs, activeTab, onChange, className, ariaLabel }: TabNavProps): JSX.Element {
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const currentIndex = tabs.findIndex((tab) => tab.id === activeTab);
+    if (currentIndex === -1) {
+      return;
+    }
+
+    if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+      event.preventDefault();
+      const direction = event.key === 'ArrowRight' ? 1 : -1;
+      const nextIndex = (currentIndex + direction + tabs.length) % tabs.length;
+      onChange(tabs[nextIndex]?.id ?? activeTab);
+      const nextButton = document.getElementById(`${tabs[nextIndex]?.id}-tab`);
+      nextButton?.focus();
+    }
+
+    if (event.key === 'Home') {
+      event.preventDefault();
+      onChange(tabs[0]?.id ?? activeTab);
+      const firstButton = document.getElementById(`${tabs[0]?.id}-tab`);
+      firstButton?.focus();
+    }
+
+    if (event.key === 'End') {
+      event.preventDefault();
+      const last = tabs.at(-1);
+      if (!last) return;
+      onChange(last.id);
+      const lastButton = document.getElementById(`${last.id}-tab`);
+      lastButton?.focus();
+    }
+  };
+
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel ?? 'Tab navigation'}
+      className={clsx('flex flex-wrap gap-2 rounded-lg bg-base-900/40 p-2', className)}
+      onKeyDown={onKeyDown}
+    >
+      {tabs.map(({ id, label, panelId }) => {
+        const selected = id === activeTab;
+        return (
+          <button
+            key={id}
+            id={`${id}-tab`}
+            role="tab"
+            type="button"
+            aria-selected={selected}
+            aria-controls={panelId}
+            className={clsx(
+              'rounded-md px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950',
+              selected
+                ? 'bg-accent-500 text-base-950 focus-visible:ring-accent-300'
+                : 'bg-base-800 text-base-200 hover:bg-base-700 focus-visible:ring-accent-400'
+            )}
+            onClick={() => onChange(id)}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/community/CommunitySection.tsx
+++ b/src/features/community/CommunitySection.tsx
@@ -1,0 +1,65 @@
+import { useState, type JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { TabNav } from '../../components/TabNav';
+import { CommentsBoard } from './comments/CommentsBoard';
+import { SimulatorSection } from '../simulator/SimulatorSection';
+import { RedFlagsCalendar } from '../redflags/RedFlagsCalendar';
+import { RedFlagForm } from '../redflags/RedFlagForm';
+import { RedFlagList } from '../redflags/RedFlagList';
+
+const TABS = ['voices', 'simulator', 'redflags'] as const;
+
+export function CommunitySection(): JSX.Element {
+  const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState<(typeof TABS)[number]>('voices');
+
+  const tabs = TABS.map((tab) => ({
+    id: tab,
+    label: t(`community.tabs.${tab}`),
+    panelId: `community-panel-${tab}`
+  }));
+
+  return (
+    <section className="space-y-8" aria-labelledby="community-section-title" role="region">
+      <header className="space-y-3">
+        <h1 id="community-section-title" className="text-3xl font-bold text-base-50 sm:text-4xl">
+          {t('community.title')}
+        </h1>
+        <p className="text-base text-base-200">{t('community.subtitle')}</p>
+      </header>
+      <TabNav
+        tabs={tabs}
+        activeTab={activeTab}
+        onChange={(id) => setActiveTab(id as (typeof TABS)[number])}
+        ariaLabel={t('community.tabs.ariaLabel')}
+      />
+      {tabs.map((tab) => (
+        <div
+          key={tab.id}
+          id={tab.panelId}
+          role="tabpanel"
+          aria-labelledby={`${tab.id}-tab`}
+          hidden={activeTab !== tab.id}
+          className="space-y-8"
+        >
+          {tab.id === 'voices' ? (
+            <CommentsBoard />
+          ) : null}
+          {tab.id === 'simulator' ? (
+            <SimulatorSection />
+          ) : null}
+          {tab.id === 'redflags' ? (
+            <div className="space-y-6">
+              <RedFlagsCalendar />
+              <div className="grid gap-6 xl:grid-cols-[1.1fr_1fr]">
+                <RedFlagList />
+                <RedFlagForm />
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/src/features/community/comments/CommentForm.tsx
+++ b/src/features/community/comments/CommentForm.tsx
@@ -1,0 +1,124 @@
+import { FormEvent, useState, type JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useCommentsStore } from './comments.store';
+
+const MAX_LENGTH = 500;
+const MIN_NICKNAME = 2;
+
+export function CommentForm(): JSX.Element {
+  const { t } = useTranslation();
+  const addComment = useCommentsStore((state) => state.addComment);
+  const activeThreadId = useCommentsStore((state) => state.activeThreadId);
+  const [nickname, setNickname] = useState('');
+  const [content, setContent] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<'idle' | 'success'>('idle');
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus('idle');
+
+    const trimmedNickname = nickname.trim();
+    const trimmedContent = content.trim();
+
+    if (trimmedNickname.length < MIN_NICKNAME) {
+      setError(t('comments.form.nicknameError'));
+      return;
+    }
+
+    if (!trimmedContent) {
+      setError(t('comments.form.contentError'));
+      return;
+    }
+
+    if (trimmedContent.length > MAX_LENGTH) {
+      setError(t('comments.form.lengthError'));
+      return;
+    }
+
+    const created = addComment({
+      nickname: trimmedNickname,
+      content: trimmedContent,
+      threadId: activeThreadId
+    });
+
+    if (!created) {
+      setError(t('comments.form.submitError'));
+      return;
+    }
+
+    setError(null);
+    setStatus('success');
+    setNickname('');
+    setContent('');
+  };
+
+  return (
+    <form
+      aria-labelledby="add-comment-title"
+      aria-describedby="comment-limit"
+      className="space-y-4 rounded-xl border border-base-800 bg-base-900/70 p-6"
+      onSubmit={handleSubmit}
+    >
+      <div className="flex items-center justify-between">
+        <h3 id="add-comment-title" className="text-lg font-semibold text-base-50">
+          {t('comments.add.title')}
+        </h3>
+        {status === 'success' ? (
+          <span className="text-sm text-accent-400" role="status">
+            {t('comments.form.success')}
+          </span>
+        ) : null}
+      </div>
+      <p id="comment-limit" className="text-sm text-base-200">
+        {t('comments.form.limit', { max: MAX_LENGTH })}
+      </p>
+      <div className="space-y-2">
+        <label htmlFor="comment-nickname" className="block text-sm font-medium text-base-100">
+          {t('comments.form.nickname')}
+        </label>
+        <input
+          id="comment-nickname"
+          name="nickname"
+          type="text"
+          required
+          minLength={MIN_NICKNAME}
+          value={nickname}
+          onChange={(event) => setNickname(event.target.value)}
+          className="w-full rounded-md border border-base-700 bg-base-900 px-3 py-2 text-base-50 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+          aria-describedby="comment-limit"
+        />
+      </div>
+      <div className="space-y-2">
+        <label htmlFor="comment-content" className="block text-sm font-medium text-base-100">
+          {t('comments.form.content')}
+        </label>
+        <textarea
+          id="comment-content"
+          name="content"
+          required
+          maxLength={MAX_LENGTH}
+          value={content}
+          onChange={(event) => setContent(event.target.value)}
+          className="h-32 w-full resize-y rounded-md border border-base-700 bg-base-900 px-3 py-2 text-base-50 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+          aria-describedby="comment-limit"
+        />
+        <div className="flex justify-between text-xs text-base-300" aria-live="polite">
+          <span>{t('comments.form.remaining', { count: MAX_LENGTH - content.length })}</span>
+          {error ? (
+            <span className="text-accent-400" role="alert">
+              {error}
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <button
+        type="submit"
+        className="inline-flex items-center justify-center rounded-md bg-accent-500 px-4 py-2 text-sm font-semibold text-base-950 transition-colors hover:bg-accent-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-300 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+      >
+        {t('comments.form.submit')}
+      </button>
+    </form>
+  );
+}

--- a/src/features/community/comments/CommentsBoard.tsx
+++ b/src/features/community/comments/CommentsBoard.tsx
@@ -1,0 +1,125 @@
+import { useTranslation } from 'react-i18next';
+import type { JSX } from 'react';
+
+import { TabNav } from '../../../components/TabNav';
+import { CommentForm } from './CommentForm';
+import { ModerationPanel } from './ModerationPanel';
+import { useCommentsStore } from './comments.store';
+
+const formatDate = (value: string, locale: string) => {
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    }).format(new Date(value));
+  } catch (error) {
+    console.warn('Failed to format comment date', error);
+    return value;
+  }
+};
+
+export function CommentsBoard(): JSX.Element {
+  const { t, i18n } = useTranslation();
+  const threads = useCommentsStore((state) => state.threads);
+  const comments = useCommentsStore((state) => state.comments);
+  const activeThreadId = useCommentsStore((state) => state.activeThreadId);
+  const setActiveThread = useCommentsStore((state) => state.setActiveThread);
+
+  const activeThread = threads[activeThreadId];
+
+  const tabItems = Object.values(threads).map((thread) => ({
+    id: thread.id,
+    label: t(thread.title),
+    panelId: `${thread.id}-panel`
+  }));
+
+  return (
+    <section
+      role="region"
+      aria-labelledby="community-voices-title"
+      className="space-y-8"
+    >
+      <header className="space-y-3">
+        <h2 id="community-voices-title" className="text-2xl font-bold text-base-50">
+          {t('community.tabs.voices')}
+        </h2>
+        <p className="text-sm text-base-200">{t('comments.info.localOnly')}</p>
+      </header>
+      <TabNav
+        tabs={tabItems}
+        activeTab={activeThreadId}
+        onChange={setActiveThread}
+        ariaLabel={t('comments.threads.ariaLabel')}
+      />
+      <div
+        id={`${activeThreadId}-panel`}
+        role="tabpanel"
+        aria-labelledby={`${activeThreadId}-tab`}
+        className="grid gap-8 lg:grid-cols-[2fr_1fr]"
+      >
+        <div className="space-y-4">
+          {activeThread && activeThread.comments.length > 0 ? (
+            <ul className="space-y-4" aria-live="polite">
+              {activeThread.comments
+                .map((commentId) => comments[commentId])
+                .filter(Boolean)
+                .map((comment) => (
+                  <li key={comment!.id}>
+                    <article
+                      className="rounded-xl border border-base-800 bg-base-900/70 p-5 shadow-sm"
+                      aria-label={t('comments.card.label', { nickname: comment!.nickname })}
+                    >
+                      <header className="flex flex-wrap items-center gap-3">
+                        <span className="text-sm font-semibold text-base-100">
+                          {comment!.nickname}
+                        </span>
+                        <span className="text-xs text-base-300">
+                          {formatDate(comment!.createdAt, i18n.language)}
+                        </span>
+                        <span
+                          className="inline-flex items-center rounded-full bg-base-800 px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-wide text-base-200"
+                        >
+                          {comment!.hidden
+                            ? t('comments.status.hidden')
+                            : t('comments.status.visible')}
+                        </span>
+                        {comment!.flagged ? (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-accent-500/10 px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-wide text-accent-400">
+                            <span aria-hidden>⚠</span>
+                            {t('comments.status.flagged')}
+                          </span>
+                        ) : null}
+                      </header>
+                      <p className="mt-3 whitespace-pre-line text-sm text-base-100">
+                        {comment!.hidden ? t('comments.hiddenMessage') : comment!.content}
+                      </p>
+                      <ModerationPanel
+                        commentId={comment!.id}
+                        hidden={comment!.hidden}
+                        flagged={comment!.flagged}
+                      />
+                    </article>
+                  </li>
+                ))}
+            </ul>
+          ) : (
+            <p className="rounded-lg border border-dashed border-base-800 p-6 text-sm text-base-300">
+              {t('comments.empty')}
+            </p>
+          )}
+        </div>
+        <div>
+          <CommentForm />
+        </div>
+      </div>
+      <div className="rounded-lg border border-base-800 bg-base-900/40 p-4 text-xs text-base-300">
+        <p className="font-semibold text-base-100">{t('comments.safety.title')}</p>
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          <li>{t('comments.safety.anonymity')}</li>
+          <li>{t('comments.safety.noNames')}</li>
+          <li>{t('comments.safety.emergency')}</li>
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/features/community/comments/ModerationPanel.tsx
+++ b/src/features/community/comments/ModerationPanel.tsx
@@ -1,0 +1,62 @@
+import { useState, type JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ConfirmDialog } from '../../../components/ConfirmDialog';
+import { useCommentsStore } from './comments.store';
+
+type ModerationPanelProps = {
+  commentId: string;
+  hidden?: boolean;
+  flagged?: boolean;
+};
+
+export function ModerationPanel({ commentId, hidden, flagged }: ModerationPanelProps): JSX.Element {
+  const { t } = useTranslation();
+  const toggleHidden = useCommentsStore((state) => state.toggleHidden);
+  const toggleFlagged = useCommentsStore((state) => state.toggleFlagged);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const handleHideClick = () => {
+    if (hidden) {
+      toggleHidden(commentId);
+      return;
+    }
+    setDialogOpen(true);
+  };
+
+  const handleConfirmHide = () => {
+    toggleHidden(commentId);
+    setDialogOpen(false);
+  };
+
+  return (
+    <div className="mt-4 flex flex-wrap items-center gap-2" aria-label={t('comments.moderation.label')}>
+      <button
+        type="button"
+        className="rounded-md border border-base-700 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-base-100 transition-colors hover:bg-base-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+        onClick={handleHideClick}
+        aria-pressed={hidden}
+        aria-label={hidden ? t('comments.moderation.unhide') : t('comments.moderation.hide')}
+      >
+        {hidden ? t('comments.moderation.unhide') : t('comments.moderation.hide')}
+      </button>
+      <button
+        type="button"
+        className="rounded-md border border-accent-500 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-accent-400 transition-colors hover:bg-accent-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-300 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+        onClick={() => toggleFlagged(commentId)}
+        aria-pressed={flagged}
+      >
+        {flagged ? t('comments.moderation.unflag') : t('comments.moderation.flag')}
+      </button>
+      <ConfirmDialog
+        open={dialogOpen}
+        title={t('comments.moderation.hideConfirmTitle')}
+        description={t('comments.moderation.hideConfirmDescription')}
+        confirmLabel={t('comments.moderation.hide')}
+        cancelLabel={t('comments.moderation.cancel')}
+        onConfirm={handleConfirmHide}
+        onCancel={() => setDialogOpen(false)}
+      />
+    </div>
+  );
+}

--- a/src/features/community/comments/comments.schema.ts
+++ b/src/features/community/comments/comments.schema.ts
@@ -1,0 +1,24 @@
+export type CommentId = string;
+
+export type Comment = {
+  id: CommentId;
+  nickname: string;
+  content: string;
+  createdAt: string;
+  hidden?: boolean;
+  flagged?: boolean;
+};
+
+export type Thread = {
+  id: string;
+  title: string;
+  description?: string;
+  comments: CommentId[];
+  createdAt: string;
+};
+
+export type CreateCommentInput = {
+  nickname: string;
+  content: string;
+  threadId: string;
+};

--- a/src/features/community/comments/comments.store.test.ts
+++ b/src/features/community/comments/comments.store.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { useCommentsStore } from './comments.store';
+
+const STORAGE_KEY = 'community-comments';
+
+const resetStore = () => {
+  useCommentsStore.getState().reset();
+  localStorage.removeItem(STORAGE_KEY);
+};
+
+describe('comments store', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  afterEach(() => {
+    resetStore();
+  });
+
+  it('adds a comment to the active thread', () => {
+    const state = useCommentsStore.getState();
+    const created = state.addComment({
+      nickname: 'Ala',
+      content: 'Pierwszy wpis',
+      threadId: state.activeThreadId
+    });
+
+    expect(created).not.toBeNull();
+    const updated = useCommentsStore.getState();
+    expect(updated.threads[updated.activeThreadId]?.comments).toContain(created?.id);
+    expect(updated.comments[created!.id]?.content).toBe('Pierwszy wpis');
+  });
+
+  it('rejects comments above the length limit', () => {
+    const { addComment, activeThreadId } = useCommentsStore.getState();
+    const longContent = 'x'.repeat(501);
+    const created = addComment({ nickname: 'TooLong', content: longContent, threadId: activeThreadId });
+
+    expect(created).toBeNull();
+    const updated = useCommentsStore.getState();
+    expect(Object.values(updated.comments)).toHaveLength(0);
+  });
+
+  it('toggles hidden status locally', () => {
+    const { addComment, activeThreadId, toggleHidden } = useCommentsStore.getState();
+    const created = addComment({ nickname: 'Basia', content: 'Ukryj mnie', threadId: activeThreadId });
+    expect(created).not.toBeNull();
+
+    toggleHidden(created!.id);
+    expect(useCommentsStore.getState().comments[created!.id]?.hidden).toBe(true);
+
+    toggleHidden(created!.id);
+    expect(useCommentsStore.getState().comments[created!.id]?.hidden).toBe(false);
+  });
+
+  it('persists entries to localStorage', () => {
+    const { addComment, activeThreadId } = useCommentsStore.getState();
+    const created = addComment({ nickname: 'Mira', content: 'Test persistencji', threadId: activeThreadId });
+    expect(created).not.toBeNull();
+
+    const stored = localStorage.getItem(STORAGE_KEY);
+    expect(stored).toBeTruthy();
+    expect(stored).toContain('Test persistencji');
+  });
+});

--- a/src/features/community/comments/comments.store.ts
+++ b/src/features/community/comments/comments.store.ts
@@ -1,0 +1,189 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+import type {
+  Comment,
+  CommentId,
+  CreateCommentInput,
+  Thread
+} from './comments.schema';
+
+const FALLBACK_STORAGE: Storage = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined,
+  clear: () => undefined,
+  key: () => null,
+  get length() {
+    return 0;
+  }
+};
+
+const storage = createJSONStorage(() => {
+  if (typeof window === 'undefined') {
+    return FALLBACK_STORAGE;
+  }
+
+  try {
+    return window.localStorage;
+  } catch (error) {
+    console.warn('Unable to access localStorage for comments store', error);
+    return FALLBACK_STORAGE;
+  }
+});
+
+const defaultThreads: Record<string, Thread> = {
+  general: {
+    id: 'general',
+    title: 'community.comments.threads.general',
+    description: 'community.comments.threads.generalDescription',
+    comments: [],
+    createdAt: new Date().toISOString()
+  },
+  boundaries: {
+    id: 'boundaries',
+    title: 'community.comments.threads.boundaries',
+    description: 'community.comments.threads.boundariesDescription',
+    comments: [],
+    createdAt: new Date().toISOString()
+  },
+  victories: {
+    id: 'victories',
+    title: 'community.comments.threads.victories',
+    description: 'community.comments.threads.victoriesDescription',
+    comments: [],
+    createdAt: new Date().toISOString()
+  }
+};
+
+export type CommentsState = {
+  threads: Record<string, Thread>;
+  comments: Record<CommentId, Comment>;
+  activeThreadId: string;
+  addComment: (input: CreateCommentInput) => Comment | null;
+  toggleHidden: (id: CommentId) => void;
+  toggleFlagged: (id: CommentId) => void;
+  setActiveThread: (threadId: string) => void;
+  reset: () => void;
+};
+
+const createComment = ({ nickname, content }: CreateCommentInput): Comment => {
+  const trimmedContent = content.trim();
+  const trimmedNickname = nickname.trim();
+
+  if (!trimmedContent || !trimmedNickname) {
+    throw new Error('nickname and content are required');
+  }
+
+  if (trimmedContent.length > 500) {
+    throw new Error('content must be <= 500 characters');
+  }
+
+  return {
+    id: typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+    nickname: trimmedNickname,
+    content: trimmedContent,
+    createdAt: new Date().toISOString(),
+    hidden: false,
+    flagged: false
+  };
+};
+
+export const useCommentsStore = create<CommentsState>()(
+  persist(
+    (set, get) => ({
+      threads: defaultThreads,
+      comments: {},
+      activeThreadId: 'general',
+      addComment: (input) => {
+        const state = get();
+        const thread = state.threads[input.threadId];
+
+        if (!thread) {
+          console.warn('Unknown thread for comment', input.threadId);
+          return null;
+        }
+
+        let comment: Comment;
+        try {
+          comment = createComment(input);
+        } catch (error) {
+          console.warn('Failed to create comment', error);
+          return null;
+        }
+
+        set(({ comments, threads }) => ({
+          comments: {
+            ...comments,
+            [comment.id]: comment
+          },
+          threads: {
+            ...threads,
+            [thread.id]: {
+              ...thread,
+              comments: [...thread.comments, comment.id]
+            }
+          }
+        }));
+
+        return comment;
+      },
+      toggleHidden: (id) =>
+        set(({ comments }) => {
+          const comment = comments[id];
+          if (!comment) {
+            return { comments };
+          }
+
+          return {
+            comments: {
+              ...comments,
+              [id]: { ...comment, hidden: !comment.hidden }
+            }
+          };
+        }),
+      toggleFlagged: (id) =>
+        set(({ comments }) => {
+          const comment = comments[id];
+          if (!comment) {
+            return { comments };
+          }
+
+          return {
+            comments: {
+              ...comments,
+              [id]: { ...comment, flagged: !comment.flagged }
+            }
+          };
+        }),
+      setActiveThread: (threadId) => {
+        if (!get().threads[threadId]) {
+          return;
+        }
+        set({ activeThreadId: threadId });
+      },
+      reset: () =>
+        set(() => ({
+          threads: Object.fromEntries(
+            Object.entries(defaultThreads).map(([id, thread]) => [
+              id,
+              { ...thread, comments: [] }
+            ])
+          ),
+          comments: {},
+          activeThreadId: 'general'
+        }))
+    }),
+    {
+      name: 'community-comments',
+      storage,
+      partialize: (state) => ({
+        threads: state.threads,
+        comments: state.comments,
+        activeThreadId: state.activeThreadId
+      })
+    }
+  )
+);

--- a/src/features/redflags/RedFlagForm.tsx
+++ b/src/features/redflags/RedFlagForm.tsx
@@ -1,0 +1,150 @@
+import { FormEvent, useState, type JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useRedFlagsStore } from './redflags.store';
+import type { RedFlagCategory } from './redflags.schema';
+
+const MAX_NOTE = 500;
+
+const categories: RedFlagCategory[] = [
+  'gaslighting',
+  'financial_abuse',
+  'stalking',
+  'legal_weaponization',
+  'emotional_blackmail',
+  'devaluation',
+  'discard',
+  'hoovering'
+];
+
+export function RedFlagForm(): JSX.Element {
+  const { t } = useTranslation();
+  const addEntry = useRedFlagsStore((state) => state.addEntry);
+  const [date, setDate] = useState('');
+  const [category, setCategory] = useState<RedFlagCategory>('gaslighting');
+  const [intensity, setIntensity] = useState<1 | 2 | 3 | 4 | 5>(3);
+  const [note, setNote] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<'idle' | 'success'>('idle');
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus('idle');
+
+    if (!date) {
+      setError(t('rf.form.dateError'));
+      return;
+    }
+
+    if (note.length > MAX_NOTE) {
+      setError(t('rf.form.limitError'));
+      return;
+    }
+
+    const created = addEntry({ date, category, intensity, note: note.trim() || undefined });
+    if (!created) {
+      setError(t('rf.form.submitError'));
+      return;
+    }
+
+    setError(null);
+    setStatus('success');
+    setNote('');
+  };
+
+  return (
+    <form
+      className="space-y-4 rounded-xl border border-base-800 bg-base-900/70 p-6"
+      aria-labelledby="redflag-form-title"
+      onSubmit={handleSubmit}
+    >
+      <div className="flex items-center justify-between">
+        <h3 id="redflag-form-title" className="text-lg font-semibold text-base-50">
+          {t('rf.add')}
+        </h3>
+        {status === 'success' ? (
+          <span className="text-sm text-accent-400" role="status">
+            {t('rf.form.success')}
+          </span>
+        ) : null}
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="redflag-date" className="block text-sm font-medium text-base-100">
+            {t('rf.date')}
+          </label>
+          <input
+            id="redflag-date"
+            type="date"
+            value={date}
+            onChange={(event) => setDate(event.target.value)}
+            className="w-full rounded-md border border-base-700 bg-base-900 px-3 py-2 text-sm text-base-50 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+            aria-describedby="redflag-note-limit"
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="redflag-category" className="block text-sm font-medium text-base-100">
+            {t('rf.category')}
+          </label>
+          <select
+            id="redflag-category"
+            value={category}
+            onChange={(event) => setCategory(event.target.value as RedFlagCategory)}
+            className="w-full rounded-md border border-base-700 bg-base-900 px-3 py-2 text-sm text-base-50 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+          >
+            {categories.map((option) => (
+              <option key={option} value={option}>
+                {t(`rf.categories.${option}`)}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="redflag-intensity" className="block text-sm font-medium text-base-100">
+            {t('rf.intensity')}
+          </label>
+          <input
+            id="redflag-intensity"
+            type="range"
+            min={1}
+            max={5}
+            value={intensity}
+            onChange={(event) => setIntensity(Number(event.target.value) as 1 | 2 | 3 | 4 | 5)}
+            className="w-full"
+          />
+          <span className="text-xs text-base-300" aria-live="polite">
+            {t('rf.form.intensityValue', { value: intensity })}
+          </span>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <label htmlFor="redflag-note" className="block text-sm font-medium text-base-100">
+          {t('rf.note')}
+        </label>
+        <textarea
+          id="redflag-note"
+          value={note}
+          onChange={(event) => setNote(event.target.value)}
+          maxLength={MAX_NOTE}
+          className="h-32 w-full resize-y rounded-md border border-base-700 bg-base-900 px-3 py-2 text-sm text-base-50 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+          aria-describedby="redflag-note-limit"
+        />
+        <div className="flex justify-between text-xs text-base-300" aria-live="polite">
+          <span id="redflag-note-limit">{t('rf.form.limit', { max: MAX_NOTE })}</span>
+          {error ? (
+            <span className="text-accent-400" role="alert">
+              {error}
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <button
+        type="submit"
+        className="inline-flex items-center justify-center rounded-md bg-accent-500 px-4 py-2 text-sm font-semibold text-base-950 transition-colors hover:bg-accent-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-300 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+      >
+        {t('rf.form.submit')}
+      </button>
+    </form>
+  );
+}

--- a/src/features/redflags/RedFlagList.test.tsx
+++ b/src/features/redflags/RedFlagList.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RedFlagList } from './RedFlagList';
+import { useRedFlagsStore } from './redflags.store';
+import type { RedFlagEntry } from './redflags.schema';
+
+const seedEntries: RedFlagEntry[] = [
+  {
+    id: '1',
+    date: '2024-01-10',
+    category: 'gaslighting',
+    intensity: 4,
+    note: 'Podważanie faktów',
+    createdAt: '2024-01-10T10:00:00.000Z'
+  },
+  {
+    id: '2',
+    date: '2024-01-12',
+    category: 'discard',
+    intensity: 2,
+    note: 'Nagłe zrywanie kontaktu',
+    createdAt: '2024-01-12T12:00:00.000Z'
+  }
+];
+
+describe('RedFlagList', () => {
+  beforeEach(() => {
+    useRedFlagsStore.setState({ entries: seedEntries });
+  });
+
+  afterEach(() => {
+    useRedFlagsStore.setState({ entries: [] });
+  });
+
+  it('filters entries by category', () => {
+    render(<RedFlagList />);
+
+    const list = screen.getByRole('list');
+    expect(within(list).getAllByRole('listitem')).toHaveLength(2);
+
+    const categorySelect = screen.getByLabelText(/kategoria|category|categorie/i);
+    fireEvent.change(categorySelect, { target: { value: 'gaslighting' } });
+
+    const listItems = within(screen.getByRole('list')).getAllByRole('listitem');
+    expect(listItems).toHaveLength(1);
+    expect(within(listItems[0]!).getByText(/Podważanie faktów/i)).toBeInTheDocument();
+  });
+
+  it('exports entries to JSON', async () => {
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:url');
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const appendSpy = vi.spyOn(document.body, 'append');
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    render(<RedFlagList />);
+
+    const exportButton = screen.getByRole('button', { name: /eksportuj|export/i });
+    fireEvent.click(exportButton);
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(appendSpy).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalled();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:url');
+
+    const blob = createObjectURL.mock.calls[0]?.[0] as Blob;
+    const text = await blob.text();
+    expect(text).toContain('Podważanie faktów');
+
+    createObjectURL.mockRestore();
+    revokeObjectURL.mockRestore();
+    appendSpy.mockRestore();
+    clickSpy.mockRestore();
+  });
+});

--- a/src/features/redflags/RedFlagList.tsx
+++ b/src/features/redflags/RedFlagList.tsx
@@ -1,0 +1,201 @@
+import { useMemo, useState, type JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useRedFlagsStore } from './redflags.store';
+import type { RedFlagCategory, RedFlagEntry } from './redflags.schema';
+
+const categories: Array<RedFlagCategory | 'all'> = [
+  'all',
+  'gaslighting',
+  'financial_abuse',
+  'stalking',
+  'legal_weaponization',
+  'emotional_blackmail',
+  'devaluation',
+  'discard',
+  'hoovering'
+];
+
+const formatDate = (value: string, locale: string) => {
+  try {
+    return new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(new Date(value));
+  } catch (error) {
+    console.warn('Failed to format red flag date', error);
+    return value;
+  }
+};
+
+const shouldInclude = (
+  entry: RedFlagEntry,
+  filters: {
+    category: RedFlagCategory | 'all';
+    intensity: number | 'all';
+    from: string;
+    to: string;
+  }
+) => {
+  const date = entry.date;
+  if (filters.from && date < filters.from) {
+    return false;
+  }
+  if (filters.to && date > filters.to) {
+    return false;
+  }
+  if (filters.category !== 'all' && entry.category !== filters.category) {
+    return false;
+  }
+  if (filters.intensity !== 'all' && entry.intensity !== filters.intensity) {
+    return false;
+  }
+  return true;
+};
+
+export function RedFlagList(): JSX.Element {
+  const { t, i18n } = useTranslation();
+  const entries = useRedFlagsStore((state) => state.entries);
+  const [filters, setFilters] = useState<{
+    from: string;
+    to: string;
+    category: RedFlagCategory | 'all';
+    intensity: number | 'all';
+  }>({ from: '', to: '', category: 'all', intensity: 'all' });
+
+  const filteredEntries = useMemo(
+    () => entries.filter((entry) => shouldInclude(entry, filters)),
+    [entries, filters]
+  );
+
+  const handleExport = () => {
+    try {
+      const data = JSON.stringify(entries, null, 2);
+      const blob = new Blob([data], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `red-flags-${new Date().toISOString()}.json`;
+      document.body.append(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.warn('Failed to export red flag log', error);
+    }
+  };
+
+  const updateFilter = <Key extends keyof typeof filters>(key: Key, value: (typeof filters)[Key]) => {
+    setFilters((current) => ({ ...current, [key]: value }));
+  };
+
+  return (
+    <section
+      aria-labelledby="redflag-list-title"
+      className="space-y-4 rounded-xl border border-base-800 bg-base-900/70 p-6"
+    >
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <h3 id="redflag-list-title" className="text-lg font-semibold text-base-50">
+          {t('rf.list.title')}
+        </h3>
+        <button
+          type="button"
+          onClick={handleExport}
+          className="inline-flex items-center justify-center rounded-md bg-accent-500 px-4 py-2 text-sm font-semibold text-base-950 transition-colors hover:bg-accent-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-300 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+        >
+          {t('rf.export')}
+        </button>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="space-y-2">
+          <label htmlFor="filter-from" className="block text-xs font-medium text-base-200">
+            {t('rf.filter.from')}
+          </label>
+          <input
+            id="filter-from"
+            type="date"
+            value={filters.from}
+            onChange={(event) => updateFilter('from', event.target.value)}
+            className="w-full rounded-md border border-base-700 bg-base-900 px-3 py-2 text-sm text-base-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="filter-to" className="block text-xs font-medium text-base-200">
+            {t('rf.filter.to')}
+          </label>
+          <input
+            id="filter-to"
+            type="date"
+            value={filters.to}
+            onChange={(event) => updateFilter('to', event.target.value)}
+            className="w-full rounded-md border border-base-700 bg-base-900 px-3 py-2 text-sm text-base-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="filter-category" className="block text-xs font-medium text-base-200">
+            {t('rf.filter.category')}
+          </label>
+          <select
+            id="filter-category"
+            value={filters.category}
+            onChange={(event) => updateFilter('category', event.target.value as RedFlagCategory | 'all')}
+            className="w-full rounded-md border border-base-700 bg-base-900 px-3 py-2 text-sm text-base-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+          >
+            {categories.map((option) => (
+              <option key={option} value={option}>
+                {option === 'all' ? t('rf.filter.all') : t(`rf.categories.${option}`)}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="filter-intensity" className="block text-xs font-medium text-base-200">
+            {t('rf.filter.intensity')}
+          </label>
+          <select
+            id="filter-intensity"
+            value={filters.intensity}
+            onChange={(event) => {
+              const value = event.target.value;
+              updateFilter('intensity', value === 'all' ? 'all' : Number(value));
+            }}
+            className="w-full rounded-md border border-base-700 bg-base-900 px-3 py-2 text-sm text-base-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+          >
+            <option value="all">{t('rf.filter.all')}</option>
+            {[1, 2, 3, 4, 5].map((level) => (
+              <option key={level} value={level}>
+                {t('rf.filter.intensityValue', { value: level })}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      {filteredEntries.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-base-800 p-6 text-sm text-base-300">
+          {t('rf.none')}
+        </p>
+      ) : (
+        <ul className="space-y-4" aria-live="polite">
+          {filteredEntries
+            .slice()
+            .sort((a, b) => (a.date < b.date ? 1 : -1))
+            .map((entry) => (
+              <li key={entry.id} className="rounded-lg border border-base-800 bg-base-900/60 p-4">
+                <div className="flex flex-wrap items-center gap-3">
+                  <p className="text-sm font-semibold text-base-100">
+                    {formatDate(entry.date, i18n.language)}
+                  </p>
+                  <span className="rounded-full bg-accent-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-accent-300">
+                    {t(`rf.categories.${entry.category}`)}
+                  </span>
+                  <span className="text-xs text-base-300">
+                    {t('rf.filter.intensityValue', { value: entry.intensity })}
+                  </span>
+                </div>
+                {entry.note ? (
+                  <p className="mt-3 whitespace-pre-line text-sm text-base-200">{entry.note}</p>
+                ) : null}
+              </li>
+            ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/features/redflags/RedFlagsCalendar.tsx
+++ b/src/features/redflags/RedFlagsCalendar.tsx
@@ -1,0 +1,151 @@
+import { useMemo, useState, type JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useRedFlagsStore } from './redflags.store';
+
+const WEEK_DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+
+const addDays = (date: Date, amount: number) => {
+  const copy = new Date(date);
+  copy.setDate(copy.getDate() + amount);
+  return copy;
+};
+
+const toKey = (date: Date) => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+export function RedFlagsCalendar(): JSX.Element {
+  const { t, i18n } = useTranslation();
+  const entries = useRedFlagsStore((state) => state.entries);
+  const today = useMemo(() => new Date(), []);
+  const [currentMonth, setCurrentMonth] = useState(() => new Date(today.getFullYear(), today.getMonth(), 1));
+  const [focusedDate, setFocusedDate] = useState<Date>(today);
+
+  const entriesByDate = useMemo(() => {
+    return entries.reduce<Record<string, number>>((acc, entry) => {
+      acc[entry.date] = (acc[entry.date] ?? 0) + 1;
+      return acc;
+    }, {});
+  }, [entries]);
+
+  const firstDayOfMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1);
+  const startWeekDay = (firstDayOfMonth.getDay() + 6) % 7; // 0=Monday
+  const firstVisibleDate = addDays(firstDayOfMonth, -startWeekDay);
+  const days = Array.from({ length: 42 }, (_, index) => addDays(firstVisibleDate, index));
+
+  const isToday = (date: Date) => toKey(date) === toKey(today);
+  const monthLabel = new Intl.DateTimeFormat(i18n.language, {
+    month: 'long',
+    year: 'numeric'
+  }).format(currentMonth);
+
+  const handleArrowNavigation = (date: Date, key: string) => {
+    const map: Record<string, number> = {
+      ArrowRight: 1,
+      ArrowLeft: -1,
+      ArrowUp: -7,
+      ArrowDown: 7
+    };
+    const delta = map[key];
+    if (!delta) return;
+    const nextDate = addDays(date, delta);
+    setFocusedDate(nextDate);
+    setCurrentMonth(new Date(nextDate.getFullYear(), nextDate.getMonth(), 1));
+  };
+
+  return (
+    <section
+      aria-labelledby="redflags-calendar-title"
+      className="space-y-4 rounded-xl border border-base-800 bg-base-900/70 p-6"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 id="redflags-calendar-title" className="text-lg font-semibold text-base-50">
+            {t('rf.calendar.title')}
+          </h3>
+          <p className="text-sm text-base-200">{t('rf.calendar.subtitle')}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() =>
+              setCurrentMonth(
+                (value) => new Date(value.getFullYear(), value.getMonth() - 1, 1)
+              )
+            }
+            className="rounded-md border border-base-700 px-3 py-2 text-sm text-base-100 hover:bg-base-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+            aria-label={t('rf.calendar.prevMonth') ?? 'Previous month'}
+          >
+            {t('rf.calendar.prevShort')}
+          </button>
+          <p className="min-w-[8rem] text-center text-sm font-semibold text-base-100" aria-live="polite">
+            {monthLabel}
+          </p>
+          <button
+            type="button"
+            onClick={() =>
+              setCurrentMonth(
+                (value) => new Date(value.getFullYear(), value.getMonth() + 1, 1)
+              )
+            }
+            className="rounded-md border border-base-700 px-3 py-2 text-sm text-base-100 hover:bg-base-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+            aria-label={t('rf.calendar.nextMonth') ?? 'Next month'}
+          >
+            {t('rf.calendar.nextShort')}
+          </button>
+        </div>
+      </div>
+      <div role="grid" aria-label={t('rf.calendar.ariaLabel')} className="grid grid-cols-7 gap-2 text-sm">
+        {WEEK_DAYS.map((dayKey) => (
+          <div
+            key={dayKey}
+            role="columnheader"
+            className="text-center text-xs font-semibold uppercase tracking-wide text-base-300"
+            aria-label={t(`rf.calendar.week.${dayKey}`)}
+          >
+            {t(`rf.calendar.week.${dayKey}Short`)}
+          </div>
+        ))}
+        {days.map((date) => {
+          const key = toKey(date);
+          const inCurrentMonth = date.getMonth() === currentMonth.getMonth();
+          const count = entriesByDate[key] ?? 0;
+          const isFocused = toKey(focusedDate) === key;
+          return (
+            <button
+              key={key}
+              role="gridcell"
+              type="button"
+              tabIndex={isFocused ? 0 : -1}
+              onFocus={() => setFocusedDate(date)}
+              onKeyDown={(event) => handleArrowNavigation(date, event.key)}
+              onClick={() => setFocusedDate(date)}
+              className={`flex h-20 flex-col items-start justify-between rounded-lg border p-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-300 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950 ${
+                inCurrentMonth ? 'border-base-800 bg-base-900/60 text-base-100' : 'border-base-900 bg-base-900/30 text-base-500'
+              } ${count > 0 ? 'shadow-[0_0_0_1px_rgba(255,107,53,0.4)]' : ''}`}
+              aria-selected={isFocused}
+              aria-current={isToday(date) ? 'date' : undefined}
+              aria-label={t('rf.calendar.dayAria', {
+                date: new Intl.DateTimeFormat(i18n.language, {
+                  dateStyle: 'full'
+                }).format(date),
+                count
+              })}
+            >
+              <span className="text-sm font-semibold">{date.getDate()}</span>
+              {count > 0 ? (
+                <span className="rounded-full bg-accent-500/20 px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide text-accent-300">
+                  {t('rf.calendar.count', { count })}
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/features/redflags/redflags.schema.ts
+++ b/src/features/redflags/redflags.schema.ts
@@ -1,0 +1,25 @@
+export type RedFlagCategory =
+  | 'gaslighting'
+  | 'financial_abuse'
+  | 'stalking'
+  | 'legal_weaponization'
+  | 'emotional_blackmail'
+  | 'devaluation'
+  | 'discard'
+  | 'hoovering';
+
+export type RedFlagEntry = {
+  id: string;
+  date: string; // YYYY-MM-DD
+  category: RedFlagCategory;
+  intensity: 1 | 2 | 3 | 4 | 5;
+  note?: string;
+  createdAt: string;
+};
+
+export type CreateRedFlagInput = {
+  date: string;
+  category: RedFlagCategory;
+  intensity: 1 | 2 | 3 | 4 | 5;
+  note?: string;
+};

--- a/src/features/redflags/redflags.store.test.ts
+++ b/src/features/redflags/redflags.store.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { useRedFlagsStore } from './redflags.store';
+
+const STORAGE_KEY = 'community-redflags';
+
+const resetStore = () => {
+  useRedFlagsStore.setState({ entries: [] });
+  localStorage.removeItem(STORAGE_KEY);
+};
+
+describe('red flags store', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  afterEach(() => {
+    resetStore();
+  });
+
+  it('creates a new entry with trimmed note', () => {
+    const created = useRedFlagsStore.getState().addEntry({
+      date: '2024-05-01',
+      category: 'gaslighting',
+      intensity: 4,
+      note: '  test  '
+    });
+
+    expect(created).not.toBeNull();
+    const entries = useRedFlagsStore.getState().entries;
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.note).toBe('test');
+  });
+
+  it('removes entries by id', () => {
+    const store = useRedFlagsStore.getState();
+    const created = store.addEntry({ date: '2024-01-01', category: 'discard', intensity: 2 });
+    expect(created).not.toBeNull();
+
+    useRedFlagsStore.getState().removeEntry(created!.id);
+    expect(useRedFlagsStore.getState().entries).toHaveLength(0);
+  });
+
+  it('persists entries to localStorage', () => {
+    const { addEntry } = useRedFlagsStore.getState();
+    addEntry({ date: '2024-02-10', category: 'emotional_blackmail', intensity: 5, note: 'Test notatki' });
+    const stored = localStorage.getItem(STORAGE_KEY);
+    expect(stored).toBeTruthy();
+    expect(stored).toContain('Test notatki');
+  });
+});

--- a/src/features/redflags/redflags.store.ts
+++ b/src/features/redflags/redflags.store.ts
@@ -1,0 +1,84 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+import type { CreateRedFlagInput, RedFlagEntry } from './redflags.schema';
+
+const FALLBACK_STORAGE: Storage = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined,
+  clear: () => undefined,
+  key: () => null,
+  get length() {
+    return 0;
+  }
+};
+
+const storage = createJSONStorage(() => {
+  if (typeof window === 'undefined') {
+    return FALLBACK_STORAGE;
+  }
+
+  try {
+    return window.localStorage;
+  } catch (error) {
+    console.warn('Unable to access localStorage for red flags store', error);
+    return FALLBACK_STORAGE;
+  }
+});
+
+export type RedFlagsState = {
+  entries: RedFlagEntry[];
+  addEntry: (input: CreateRedFlagInput) => RedFlagEntry | null;
+  removeEntry: (id: string) => void;
+  clear: () => void;
+};
+
+const createEntry = ({ date, category, intensity, note }: CreateRedFlagInput): RedFlagEntry => {
+  if (!date) {
+    throw new Error('date is required');
+  }
+
+  if (note && note.length > 500) {
+    throw new Error('note must be <= 500 characters');
+  }
+
+  const id = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+
+  return {
+    id,
+    date,
+    category,
+    intensity,
+    note: note?.trim() || undefined,
+    createdAt: new Date().toISOString()
+  };
+};
+
+export const useRedFlagsStore = create<RedFlagsState>()(
+  persist(
+    (set) => ({
+      entries: [],
+      addEntry: (input) => {
+        try {
+          const entry = createEntry(input);
+          set((state) => ({ entries: [...state.entries, entry] }));
+          return entry;
+        } catch (error) {
+          console.warn('Failed to add red flag entry', error);
+          return null;
+        }
+      },
+      removeEntry: (id) =>
+        set((state) => ({ entries: state.entries.filter((entry) => entry.id !== id) })),
+      clear: () => set({ entries: [] })
+    }),
+    {
+      name: 'community-redflags',
+      storage,
+      partialize: (state) => ({ entries: state.entries })
+    }
+  )
+);

--- a/src/features/simulator/AnalysisPanel.tsx
+++ b/src/features/simulator/AnalysisPanel.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next';
+import type { JSX } from 'react';
+
+import { techniqueCatalog, TechniqueId } from './engine/rules';
+
+type AnalysisPanelProps = {
+  techniques: TechniqueId[];
+};
+
+export function AnalysisPanel({ techniques }: AnalysisPanelProps): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <section
+      aria-labelledby="analysis-panel-title"
+      className="space-y-4 rounded-xl border border-base-800 bg-base-900/70 p-5"
+    >
+      <header className="space-y-1">
+        <h3 id="analysis-panel-title" className="text-lg font-semibold text-base-50">
+          {t('sim.analysis.title')}
+        </h3>
+        <p className="text-sm text-base-200">{t('sim.techniques.detected')}</p>
+      </header>
+      {techniques.length === 0 ? (
+        <p className="text-sm text-base-300">{t('sim.analysis.none')}</p>
+      ) : (
+        <ul className="space-y-3">
+          {techniques.map((technique) => {
+            const catalogEntry = techniqueCatalog[technique];
+            if (!catalogEntry) return null;
+            return (
+              <li
+                key={technique}
+                className="rounded-lg border border-accent-500/40 bg-accent-500/5 p-4"
+                aria-live="polite"
+              >
+                <p className="text-sm font-semibold text-accent-300">
+                  {t(catalogEntry.labelKey)}
+                </p>
+                <p className="mt-2 text-sm text-base-100">
+                  {t(catalogEntry.descriptionKey)}
+                </p>
+                <p className="mt-2 text-xs text-base-300">{t(catalogEntry.tipKey)}</p>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/features/simulator/MessageList.tsx
+++ b/src/features/simulator/MessageList.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef, type JSX } from 'react';
+import clsx from 'clsx';
+
+export type ConversationMessage = {
+  id: string;
+  role: 'user' | 'bot';
+  content: string;
+};
+
+type MessageListProps = {
+  messages: ConversationMessage[];
+  userLabel: string;
+  botLabel: string;
+};
+
+export function MessageList({ messages, userLabel, botLabel }: MessageListProps): JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+    element.scrollTop = element.scrollHeight;
+  }, [messages]);
+
+  return (
+    <div
+      ref={containerRef}
+      role="log"
+      aria-live="polite"
+      className="h-80 overflow-y-auto rounded-xl border border-base-800 bg-base-900/70 p-4"
+    >
+      <ul className="space-y-4">
+        {messages.map((message) => (
+          <li key={message.id} className="flex">
+            <div
+              className={clsx(
+                'max-w-[80%] rounded-lg px-4 py-3 text-sm shadow',
+                message.role === 'user'
+                  ? 'ml-auto bg-accent-500 text-base-950'
+                  : 'mr-auto bg-base-800 text-base-100'
+              )}
+              aria-label={message.role === 'user' ? userLabel : botLabel}
+            >
+              <p className="whitespace-pre-line">{message.content}</p>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/simulator/SimulatorSection.tsx
+++ b/src/features/simulator/SimulatorSection.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useMemo, useState, type JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { MessageList, type ConversationMessage } from './MessageList';
+import { UserInput } from './UserInput';
+import { AnalysisPanel } from './AnalysisPanel';
+import { evaluateMessage, TechniqueId } from './engine/rules';
+
+const createId = () =>
+  (typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`);
+
+export function SimulatorSection(): JSX.Element {
+  const { t, i18n } = useTranslation();
+  const [input, setInput] = useState('');
+  const createWelcomeMessage = useMemo(
+    () => () => ({
+      id: createId(),
+      role: 'bot' as const,
+      content: t('sim.responses.welcome') ?? ''
+    }),
+    [t]
+  );
+  const [messages, setMessages] = useState<ConversationMessage[]>(() => [createWelcomeMessage()]);
+  const [detectedTechniques, setDetectedTechniques] = useState<TechniqueId[]>([]);
+
+  useEffect(() => {
+    setMessages((current) => {
+      if (current.length === 0) {
+        return [createWelcomeMessage()];
+      }
+      const [first, ...rest] = current;
+      if (first.role !== 'bot') {
+        return current;
+      }
+      return [{ ...first, content: t('sim.responses.welcome') ?? '' }, ...rest];
+    });
+  }, [i18n.language, createWelcomeMessage, t]);
+
+  const appendMessage = (message: ConversationMessage) => {
+    setMessages((current) => [...current, message]);
+  };
+
+  const resetConversation = () => {
+    setMessages([createWelcomeMessage()]);
+    setDetectedTechniques([]);
+    setInput('');
+  };
+
+  const handleSend = (raw: string) => {
+    const content = raw.trim();
+    if (!content) return;
+    const userMessage: ConversationMessage = {
+      id: createId(),
+      role: 'user',
+      content
+    };
+    appendMessage(userMessage);
+
+    const result = evaluateMessage(content);
+    const botMessage: ConversationMessage = {
+      id: createId(),
+      role: 'bot',
+      content: t(result.rule.responseKey)
+    };
+    appendMessage(botMessage);
+
+    setDetectedTechniques((current) => {
+      const unique = new Set<TechniqueId>([...current, ...result.techniques]);
+      return Array.from(unique);
+    });
+    setInput('');
+  };
+
+  return (
+    <section
+      role="region"
+      aria-labelledby="simulator-title"
+      className="space-y-8"
+    >
+      <header className="space-y-3">
+        <h2 id="simulator-title" className="text-2xl font-bold text-base-50">
+          {t('sim.title')}
+        </h2>
+        <p className="text-sm text-base-200">{t('sim.subtitle')}</p>
+      </header>
+      <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+        <div className="space-y-4">
+          <MessageList
+            messages={messages}
+            userLabel={t('sim.userLabel')}
+            botLabel={t('sim.botLabel')}
+          />
+          <UserInput value={input} onChange={setInput} onSubmit={handleSend} onReset={resetConversation} />
+        </div>
+        <AnalysisPanel techniques={detectedTechniques} />
+      </div>
+      <p className="rounded-lg border border-base-800 bg-base-900/40 p-4 text-xs text-base-300">
+        {t('sim.disclaimer')}
+      </p>
+    </section>
+  );
+}

--- a/src/features/simulator/UserInput.tsx
+++ b/src/features/simulator/UserInput.tsx
@@ -1,0 +1,52 @@
+import { FormEvent, type JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type UserInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: (value: string) => void;
+  onReset: () => void;
+  disabled?: boolean;
+};
+
+export function UserInput({ value, onChange, onSubmit, onReset, disabled }: UserInputProps): JSX.Element {
+  const { t } = useTranslation();
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!value.trim()) return;
+    onSubmit(value);
+  };
+
+  return (
+    <form className="space-y-3" onSubmit={handleSubmit} aria-label={t('sim.input.label')}>
+      <label htmlFor="simulator-input" className="sr-only">
+        {t('sim.input.placeholder')}
+      </label>
+      <textarea
+        id="simulator-input"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={t('sim.input.placeholder') ?? ''}
+        className="h-24 w-full resize-y rounded-md border border-base-700 bg-base-900 px-3 py-2 text-sm text-base-50 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+        aria-label={t('sim.input.placeholder') ?? ''}
+      />
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="submit"
+          disabled={disabled}
+          className="inline-flex items-center justify-center rounded-md bg-accent-500 px-4 py-2 text-sm font-semibold text-base-950 transition-colors hover:bg-accent-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-300 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {t('sim.send')}
+        </button>
+        <button
+          type="button"
+          onClick={onReset}
+          className="inline-flex items-center justify-center rounded-md border border-base-700 px-4 py-2 text-sm font-semibold text-base-100 transition-colors hover:bg-base-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-2 focus-visible:ring-offset-base-950"
+        >
+          {t('sim.reset')}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/simulator/engine/rules.test.ts
+++ b/src/features/simulator/engine/rules.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { evaluateMessage } from './rules';
+
+describe('simulator rules', () => {
+  it('detects blame shifting pattern', () => {
+    const result = evaluateMessage('To wszystko twoja wina.');
+    expect(result.rule.id).toBe('blame_shift_your_fault');
+    expect(result.techniques).toContain('blame_shift');
+  });
+
+  it('falls back to default response when no rule matches', () => {
+    const result = evaluateMessage('Dzień dobry, jak się czujesz?');
+    expect(result.rule.id).toBe('default');
+    expect(result.techniques).toContain('gaslighting');
+  });
+});

--- a/src/features/simulator/engine/rules.ts
+++ b/src/features/simulator/engine/rules.ts
@@ -1,0 +1,112 @@
+export type TechniqueId =
+  | 'gaslighting'
+  | 'blame_shift'
+  | 'triangulation'
+  | 'love_bombing'
+  | 'guilt_tripping'
+  | 'future_faking';
+
+export type Rule = {
+  id: string;
+  triggers: RegExp[];
+  responseKey: string;
+  techniques: TechniqueId[];
+};
+
+export const techniqueCatalog: Record<
+  TechniqueId,
+  { labelKey: string; descriptionKey: string; tipKey: string }
+> = {
+  gaslighting: {
+    labelKey: 'sim.techniques.gaslighting.label',
+    descriptionKey: 'sim.techniques.gaslighting.description',
+    tipKey: 'sim.techniques.gaslighting.tip'
+  },
+  blame_shift: {
+    labelKey: 'sim.techniques.blameShift.label',
+    descriptionKey: 'sim.techniques.blameShift.description',
+    tipKey: 'sim.techniques.blameShift.tip'
+  },
+  triangulation: {
+    labelKey: 'sim.techniques.triangulation.label',
+    descriptionKey: 'sim.techniques.triangulation.description',
+    tipKey: 'sim.techniques.triangulation.tip'
+  },
+  love_bombing: {
+    labelKey: 'sim.techniques.loveBombing.label',
+    descriptionKey: 'sim.techniques.loveBombing.description',
+    tipKey: 'sim.techniques.loveBombing.tip'
+  },
+  guilt_tripping: {
+    labelKey: 'sim.techniques.guiltTripping.label',
+    descriptionKey: 'sim.techniques.guiltTripping.description',
+    tipKey: 'sim.techniques.guiltTripping.tip'
+  },
+  future_faking: {
+    labelKey: 'sim.techniques.futureFaking.label',
+    descriptionKey: 'sim.techniques.futureFaking.description',
+    tipKey: 'sim.techniques.futureFaking.tip'
+  }
+};
+
+export const rules: Rule[] = [
+  {
+    id: 'gaslighting_overreacting',
+    triggers: [/przesadzasz/i, /overreact/i, /przewrażliw/i],
+    responseKey: 'sim.responses.gaslighting.overreacting',
+    techniques: ['gaslighting']
+  },
+  {
+    id: 'blame_shift_your_fault',
+    triggers: [/twoja wina/i, /your fault/i, /gdybyś ty/i],
+    responseKey: 'sim.responses.blameShift.yourFault',
+    techniques: ['blame_shift']
+  },
+  {
+    id: 'triangulation_friends',
+    triggers: [/wszyscy/i, /friends say/i, /inni mówią/i],
+    responseKey: 'sim.responses.triangulation.everyone',
+    techniques: ['triangulation']
+  },
+  {
+    id: 'love_bombing_promises',
+    triggers: [/obiecuj/i, /promise/i, /zmienię się/i],
+    responseKey: 'sim.responses.loveBombing.promises',
+    techniques: ['love_bombing', 'future_faking']
+  },
+  {
+    id: 'guilt_tripping_sacrifice',
+    triggers: [/poświęcił/i, /sacrific/i, /wszystko robię/i],
+    responseKey: 'sim.responses.guiltTripping.sacrifice',
+    techniques: ['guilt_tripping']
+  },
+  {
+    id: 'future_faking_plans',
+    triggers: [/dom/i, /marriage/i, /ślub/i, /plan/i],
+    responseKey: 'sim.responses.futureFaking.plans',
+    techniques: ['future_faking']
+  }
+];
+
+const defaultRule: Rule = {
+  id: 'default',
+  triggers: [],
+  responseKey: 'sim.responses.default',
+  techniques: ['gaslighting']
+};
+
+export type EngineResult = {
+  rule: Rule;
+  techniques: TechniqueId[];
+};
+
+export const evaluateMessage = (message: string): EngineResult => {
+  const lower = message.toLowerCase();
+  const matched = rules.find((rule) => rule.triggers.some((trigger) => trigger.test(lower)));
+
+  if (!matched) {
+    return { rule: defaultRule, techniques: defaultRule.techniques };
+  }
+
+  return { rule: matched, techniques: matched.techniques };
+};

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -133,5 +133,209 @@
         }
       }
     }
+  },
+  "community": {
+    "title": "Interactive Zone",
+    "subtitle": "Share experiences safely, practise recognising manipulation and keep a private red flag log.",
+    "tabs": {
+      "voices": "Community Voices",
+      "simulator": "Simulator",
+      "redflags": "Red Flag Journal",
+      "ariaLabel": "Interactive zone sections"
+    }
+  },
+  "comments": {
+    "info": {
+      "localOnly": "This demo works without a backend — entries live only in your browser."
+    },
+    "add": {
+      "title": "Add a contribution"
+    },
+    "form": {
+      "nickname": "Nickname",
+      "content": "Message",
+      "submit": "Send",
+      "nicknameError": "Nickname must be at least 2 characters long.",
+      "contentError": "Please write a short message.",
+      "lengthError": "Messages are limited to {{max}} characters.",
+      "submitError": "We could not save your message locally.",
+      "success": "Saved locally",
+      "limit": "Up to {{max}} characters. Please avoid sharing identifying details.",
+      "remaining": "{{count}} characters remaining"
+    },
+    "card": {
+      "label": "Comment from {{nickname}}"
+    },
+    "status": {
+      "hidden": "Hidden",
+      "visible": "Visible",
+      "flagged": "Flagged"
+    },
+    "hiddenMessage": "This entry is hidden for you. You can show it again at any time.",
+    "empty": "No messages yet. Be the first to share a thought.",
+    "safety": {
+      "title": "Safety tips",
+      "anonymity": "Use a nickname and skip personal identifiers.",
+      "noNames": "Avoid posting names, addresses or legal information.",
+      "emergency": "If you are in danger, contact local services — this space cannot replace emergency help."
+    },
+    "moderation": {
+      "label": "Local moderation controls",
+      "hide": "Hide",
+      "unhide": "Show",
+      "flag": "Flag",
+      "unflag": "Remove flag",
+      "hideConfirmTitle": "Hide this entry?",
+      "hideConfirmDescription": "Hidden entries stay on your device and can be restored later.",
+      "cancel": "Cancel"
+    },
+    "threads": {
+      "ariaLabel": "Discussion threads",
+      "general": "Open conversations",
+      "generalDescription": "Share what is on your mind right now.",
+      "boundaries": "Boundaries and safety",
+      "boundariesDescription": "Practical tips for staying grounded and safe.",
+      "victories": "Small victories",
+      "victoriesDescription": "Celebrate the steps you are proud of."
+    }
+  },
+  "sim": {
+    "title": "Conversation simulator with a manipulator",
+    "subtitle": "Practise spotting manipulation patterns. Responses are generated offline from simple rules.",
+    "input": {
+      "label": "Send a message to the simulator",
+      "placeholder": "Write what you would like to say..."
+    },
+    "send": "Send",
+    "reset": "Reset",
+    "userLabel": "Your message",
+    "botLabel": "Manipulator response",
+    "analysis": {
+      "title": "Conversation analysis",
+      "none": "No techniques detected yet. Send a message to start the exercise."
+    },
+    "techniques": {
+      "detected": "Detected techniques",
+      "gaslighting": {
+        "label": "Gaslighting",
+        "description": "Twisting reality to make you doubt your perception.",
+        "tip": "Write down facts or ask a trusted person to reality-check."
+      },
+      "blameShift": {
+        "label": "Blame shifting",
+        "description": "Placing responsibility for their behaviour onto you.",
+        "tip": "State the observable behaviour and keep responsibilities clear."
+      },
+      "triangulation": {
+        "label": "Triangulation",
+        "description": "Using third parties to pressure or control the narrative.",
+        "tip": "Limit indirect channels and engage only in safe, direct conversations."
+      },
+      "loveBombing": {
+        "label": "Love bombing",
+        "description": "Overwhelming affection or promises to regain control.",
+        "tip": "Look for consistent actions rather than grand declarations."
+      },
+      "guiltTripping": {
+        "label": "Guilt tripping",
+        "description": "Invoking guilt to push you into compliance.",
+        "tip": "Name the tactic and reaffirm your boundaries."
+      },
+      "futureFaking": {
+        "label": "Future faking",
+        "description": "Dangling hypothetical plans to keep you attached.",
+        "tip": "Focus on what is happening now, not on promises of tomorrow."
+      }
+    },
+    "responses": {
+      "welcome": "I'm only trying to help. Tell me what's on your mind.",
+      "gaslighting": {
+        "overreacting": "You're overreacting again. Everyone knows you're too sensitive."
+      },
+      "blameShift": {
+        "yourFault": "This is your fault — if you behaved better we wouldn't have any problems."
+      },
+      "triangulation": {
+        "everyone": "Even our friends say you're the difficult one here."
+      },
+      "loveBombing": {
+        "promises": "I promise I'll change overnight, just give me another chance."
+      },
+      "guiltTripping": {
+        "sacrifice": "After everything I've sacrificed for you, this is how you repay me?"
+      },
+      "futureFaking": {
+        "plans": "Why are you upset? I already planned our future house and wedding."
+      },
+      "default": "Don't make a scene. You're imagining issues again."
+    },
+    "disclaimer": "Educational demo only. The simulator runs locally and does not store or transmit your input."
+  },
+  "rf": {
+    "title": "Red Flag Journal",
+    "add": "Add incident",
+    "date": "Date",
+    "category": "Category",
+    "intensity": "Intensity",
+    "note": "Description (optional)",
+    "export": "Export JSON",
+    "filter": {
+      "from": "From",
+      "to": "To",
+      "category": "Category filter",
+      "intensity": "Intensity filter",
+      "intensityValue": "Intensity {{value}}/5",
+      "all": "All"
+    },
+    "list": {
+      "title": "Entries"
+    },
+    "none": "No entries for the selected filters.",
+    "form": {
+      "dateError": "Choose a date.",
+      "limitError": "Notes are limited to {{max}} characters.",
+      "submitError": "We could not save the entry.",
+      "success": "Saved locally",
+      "intensityValue": "Intensity: {{value}}/5",
+      "limit": "Up to {{max}} characters.",
+      "submit": "Add entry"
+    },
+    "categories": {
+      "gaslighting": "Gaslighting",
+      "financial_abuse": "Financial abuse",
+      "stalking": "Stalking",
+      "legal_weaponization": "Legal weaponisation",
+      "emotional_blackmail": "Emotional blackmail",
+      "devaluation": "Devaluation",
+      "discard": "Discard",
+      "hoovering": "Hoovering"
+    },
+    "calendar": {
+      "title": "Monthly overview",
+      "subtitle": "Navigate with arrow keys to inspect days. Entries stay on this device.",
+      "prevMonth": "Previous month",
+      "nextMonth": "Next month",
+      "prevShort": "◀",
+      "nextShort": "▶",
+      "ariaLabel": "Calendar of recorded incidents",
+      "week": {
+        "mon": "Monday",
+        "tue": "Tuesday",
+        "wed": "Wednesday",
+        "thu": "Thursday",
+        "fri": "Friday",
+        "sat": "Saturday",
+        "sun": "Sunday",
+        "monShort": "Mon",
+        "tueShort": "Tue",
+        "wedShort": "Wed",
+        "thuShort": "Thu",
+        "friShort": "Fri",
+        "satShort": "Sat",
+        "sunShort": "Sun"
+      },
+      "dayAria": "{{date}}. Entries: {{count}}.",
+      "count": "Entries: {{count}}"
+    }
   }
 }

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -133,5 +133,209 @@
         }
       }
     }
+  },
+  "community": {
+    "title": "Interactieve zone",
+    "subtitle": "Een veilige ruimte om ervaringen te delen, manipulatie te leren herkennen en een persoonlijk logboek bij te houden.",
+    "tabs": {
+      "voices": "Stemmen van de gemeenschap",
+      "simulator": "Simulator",
+      "redflags": "Dagboek met rode vlaggen",
+      "ariaLabel": "Tabbladen interactieve zone"
+    }
+  },
+  "comments": {
+    "info": {
+      "localOnly": "Deze demo werkt zonder backend — berichten blijven alleen in je browser."
+    },
+    "add": {
+      "title": "Plaats een bericht"
+    },
+    "form": {
+      "nickname": "Schuilnaam",
+      "content": "Bericht",
+      "submit": "Verzenden",
+      "nicknameError": "De schuilnaam moet minstens 2 tekens bevatten.",
+      "contentError": "Schrijf een kort bericht.",
+      "lengthError": "Berichten mogen maximaal {{max}} tekens bevatten.",
+      "submitError": "Je bericht kon niet lokaal worden opgeslagen.",
+      "success": "Lokaal opgeslagen",
+      "limit": "Maximaal {{max}} tekens. Deel geen identificeerbare gegevens.",
+      "remaining": "{{count}} tekens resterend"
+    },
+    "card": {
+      "label": "Bericht van {{nickname}}"
+    },
+    "status": {
+      "hidden": "Verborgen",
+      "visible": "Zichtbaar",
+      "flagged": "Gemeld"
+    },
+    "hiddenMessage": "Dit bericht is voor jou verborgen. Je kunt het later opnieuw tonen.",
+    "empty": "Nog geen berichten. Deel je ervaring als eerste.",
+    "safety": {
+      "title": "Veiligheidstips",
+      "anonymity": "Gebruik een schuilnaam en laat persoonlijke details achterwege.",
+      "noNames": "Plaats geen namen, adressen of juridische gegevens.",
+      "emergency": "In een noodsituatie neem je contact op met lokale hulpdiensten — deze ruimte vervangt geen noodhulp."
+    },
+    "moderation": {
+      "label": "Lokale moderatieknoppen",
+      "hide": "Verbergen",
+      "unhide": "Tonen",
+      "flag": "Melden",
+      "unflag": "Melding verwijderen",
+      "hideConfirmTitle": "Dit bericht verbergen?",
+      "hideConfirmDescription": "Verborgen berichten blijven op je apparaat en zijn later terug te halen.",
+      "cancel": "Annuleren"
+    },
+    "threads": {
+      "ariaLabel": "Discussietopics",
+      "general": "Open gesprekken",
+      "generalDescription": "Deel wat er nu bij je speelt.",
+      "boundaries": "Grenzen en veiligheid",
+      "boundariesDescription": "Praktische tips om stevig te blijven staan.",
+      "victories": "Kleine overwinningen",
+      "victoriesDescription": "Vier stappen waar je trots op bent."
+    }
+  },
+  "sim": {
+    "title": "Gesprekssimulator met een manipulator",
+    "subtitle": "Train het herkennen van manipulatietactieken. Antwoorden worden lokaal met eenvoudige regels gegenereerd.",
+    "input": {
+      "label": "Stuur een bericht naar de simulator",
+      "placeholder": "Schrijf wat je wilt zeggen..."
+    },
+    "send": "Verzenden",
+    "reset": "Resetten",
+    "userLabel": "Jouw bericht",
+    "botLabel": "Reactie van de manipulator",
+    "analysis": {
+      "title": "Gesprekanalyse",
+      "none": "Nog geen technieken gedetecteerd. Stuur een bericht om te beginnen."
+    },
+    "techniques": {
+      "detected": "Gedetecteerde technieken",
+      "gaslighting": {
+        "label": "Gaslighting",
+        "description": "Verdraait de werkelijkheid zodat je aan jezelf gaat twijfelen.",
+        "tip": "Noteer feiten of vraag een vertrouwenspersoon om mee te kijken."
+      },
+      "blameShift": {
+        "label": "Schuld doorschuiven",
+        "description": "Schuift verantwoordelijkheid voor hun gedrag op jou af.",
+        "tip": "Blijf bij waarneembaar gedrag en benoem ieders verantwoordelijkheid."
+      },
+      "triangulation": {
+        "label": "Triangulatie",
+        "description": "Zet derden in om druk te zetten of het verhaal te sturen.",
+        "tip": "Beperk indirecte kanalen en reageer alleen op veilige, directe communicatie."
+      },
+      "loveBombing": {
+        "label": "Love bombing",
+        "description": "Overlaadt je met affectie of beloften om controle terug te krijgen.",
+        "tip": "Kijk naar consistente daden in plaats van grootse woorden."
+      },
+      "guiltTripping": {
+        "label": "Schuldgevoel opwekken",
+        "description": "Speelt in op schuld om je te laten toegeven.",
+        "tip": "Noem de tactiek en bevestig je grenzen."
+      },
+      "futureFaking": {
+        "label": "Future faking",
+        "description": "Houdt je vast met beloften over een mooie toekomst.",
+        "tip": "Let op wat er nu gebeurt, niet op beloofde plannen."
+      }
+    },
+    "responses": {
+      "welcome": "Ik probeer alleen te helpen. Vertel eens wat er is.",
+      "gaslighting": {
+        "overreacting": "Je reageert weer overdreven. Iedereen weet dat je veel te gevoelig bent."
+      },
+      "blameShift": {
+        "yourFault": "Dit is jouw schuld — als jij je normaal gedroeg hadden we geen problemen."
+      },
+      "triangulation": {
+        "everyone": "Zelfs onze vrienden zeggen dat jij degene bent met wie het moeilijk is."
+      },
+      "loveBombing": {
+        "promises": "Ik beloof dat ik van de ene op de andere dag verander, geef me nog een kans."
+      },
+      "guiltTripping": {
+        "sacrifice": "Na alles wat ik voor je heb opgeofferd, doe jij dit terug?"
+      },
+      "futureFaking": {
+        "plans": "Waarom ben je boos? Ik heb ons huis en huwelijk al helemaal gepland."
+      },
+      "default": "Doe niet zo dramatisch. Je verzint problemen."
+    },
+    "disclaimer": "Alleen voor educatie. De simulator draait offline en slaat je invoer niet extern op."
+  },
+  "rf": {
+    "title": "Dagboek met rode vlaggen",
+    "add": "Incident toevoegen",
+    "date": "Datum",
+    "category": "Categorie",
+    "intensity": "Intensiteit",
+    "note": "Beschrijving (optioneel)",
+    "export": "Exporteer JSON",
+    "filter": {
+      "from": "Van",
+      "to": "Tot",
+      "category": "Categorie-filter",
+      "intensity": "Intensiteitsfilter",
+      "intensityValue": "Intensiteit {{value}}/5",
+      "all": "Alle"
+    },
+    "list": {
+      "title": "Overzicht"
+    },
+    "none": "Geen items voor de gekozen filters.",
+    "form": {
+      "dateError": "Kies een datum.",
+      "limitError": "De beschrijving mag maximaal {{max}} tekens bevatten.",
+      "submitError": "Het item kon niet worden opgeslagen.",
+      "success": "Lokaal opgeslagen",
+      "intensityValue": "Intensiteit: {{value}}/5",
+      "limit": "Maximaal {{max}} tekens.",
+      "submit": "Opslaan"
+    },
+    "categories": {
+      "gaslighting": "Gaslighting",
+      "financial_abuse": "Financieel misbruik",
+      "stalking": "Stalking",
+      "legal_weaponization": "Misbruik van juridische middelen",
+      "emotional_blackmail": "Emotionele chantage",
+      "devaluation": "Devaluatie",
+      "discard": "Verstoting",
+      "hoovering": "Hoovering"
+    },
+    "calendar": {
+      "title": "Maandoverzicht",
+      "subtitle": "Navigeer met de pijltjestoetsen. Gegevens blijven op dit apparaat.",
+      "prevMonth": "Vorige maand",
+      "nextMonth": "Volgende maand",
+      "prevShort": "◀",
+      "nextShort": "▶",
+      "ariaLabel": "Kalender met geregistreerde incidenten",
+      "week": {
+        "mon": "Maandag",
+        "tue": "Dinsdag",
+        "wed": "Woensdag",
+        "thu": "Donderdag",
+        "fri": "Vrijdag",
+        "sat": "Zaterdag",
+        "sun": "Zondag",
+        "monShort": "Ma",
+        "tueShort": "Di",
+        "wedShort": "Wo",
+        "thuShort": "Do",
+        "friShort": "Vr",
+        "satShort": "Za",
+        "sunShort": "Zo"
+      },
+      "dayAria": "{{date}}. Aantal items: {{count}}.",
+      "count": "Items: {{count}}"
+    }
   }
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -133,5 +133,209 @@
         }
       }
     }
+  },
+  "community": {
+    "title": "Strefa Interaktywna",
+    "subtitle": "Bezpieczna przestrzeń do dzielenia się doświadczeniami, treningu rozpoznawania manipulacji i prowadzenia dziennika sygnałów ostrzegawczych.",
+    "tabs": {
+      "voices": "Głosy Społeczności",
+      "simulator": "Symulator",
+      "redflags": "Dziennik Czerwonych Flag",
+      "ariaLabel": "Zakładki strefy interaktywnej"
+    }
+  },
+  "comments": {
+    "info": {
+      "localOnly": "To demo bez backendu — wpisy są przechowywane tylko lokalnie."
+    },
+    "add": {
+      "title": "Dodaj wypowiedź"
+    },
+    "form": {
+      "nickname": "Pseudonim",
+      "content": "Treść",
+      "submit": "Wyślij",
+      "nicknameError": "Pseudonim powinien mieć co najmniej 2 znaki.",
+      "contentError": "Wpisz krótką wiadomość.",
+      "lengthError": "Wpis może mieć maksymalnie {{max}} znaków.",
+      "submitError": "Nie udało się zapisać wpisu lokalnie.",
+      "success": "Zapisano lokalnie",
+      "limit": "Do {{max}} znaków. Nie podawaj danych identyfikujących.",
+      "remaining": "Pozostało znaków: {{count}}"
+    },
+    "card": {
+      "label": "Wpis użytkownika {{nickname}}"
+    },
+    "status": {
+      "hidden": "Ukryty",
+      "visible": "Widoczny",
+      "flagged": "Zgłoszony"
+    },
+    "hiddenMessage": "Ten wpis jest ukryty. Możesz go ponownie wyświetlić w dowolnym momencie.",
+    "empty": "Brak wpisów. Podziel się swoim głosem jako pierwsza/y.",
+    "safety": {
+      "title": "Wskazówki bezpieczeństwa",
+      "anonymity": "Korzystaj z pseudonimu i pomijaj dane osobowe.",
+      "noNames": "Nie publikuj imion, adresów ani danych prawnych.",
+      "emergency": "W sytuacji zagrożenia skontaktuj się z lokalnymi służbami — to miejsce nie zastępuje pomocy alarmowej."
+    },
+    "moderation": {
+      "label": "Lokalne narzędzia moderacji",
+      "hide": "Ukryj",
+      "unhide": "Pokaż",
+      "flag": "Zgłoś",
+      "unflag": "Usuń zgłoszenie",
+      "hideConfirmTitle": "Ukryć ten wpis?",
+      "hideConfirmDescription": "Ukryte wpisy pozostają na Twoim urządzeniu i można je przywrócić.",
+      "cancel": "Anuluj"
+    },
+    "threads": {
+      "ariaLabel": "Wątki rozmów",
+      "general": "Otwarte rozmowy",
+      "generalDescription": "Podziel się tym, co teraz czujesz.",
+      "boundaries": "Granice i bezpieczeństwo",
+      "boundariesDescription": "Praktyczne wskazówki, jak zadbać o siebie.",
+      "victories": "Małe zwycięstwa",
+      "victoriesDescription": "Świętuj kroki, z których jesteś dumny/a."
+    }
+  },
+  "sim": {
+    "title": "Symulator rozmowy z manipulatorem",
+    "subtitle": "Trenuj rozpoznawanie technik manipulacji. Odpowiedzi powstają lokalnie na podstawie prostych reguł.",
+    "input": {
+      "label": "Wyślij wiadomość do symulatora",
+      "placeholder": "Napisz, co chcesz powiedzieć..."
+    },
+    "send": "Wyślij",
+    "reset": "Reset",
+    "userLabel": "Twoja wiadomość",
+    "botLabel": "Odpowiedź manipulatora",
+    "analysis": {
+      "title": "Analiza rozmowy",
+      "none": "Na razie brak wykrytych technik. Wyślij wiadomość, by rozpocząć ćwiczenie."
+    },
+    "techniques": {
+      "detected": "Wykryte techniki",
+      "gaslighting": {
+        "label": "Gaslighting",
+        "description": "Podważanie rzeczywistości, byś zwątpił/a w swoje odczucia.",
+        "tip": "Spisuj fakty lub poproś zaufaną osobę o spojrzenie z boku."
+      },
+      "blameShift": {
+        "label": "Przerzucanie winy",
+        "description": "Przerzucanie odpowiedzialności za jego/jej zachowanie na ciebie.",
+        "tip": "Nazywaj konkretne działania i przypominaj o granicach odpowiedzialności."
+      },
+      "triangulation": {
+        "label": "Triangulacja",
+        "description": "Wykorzystywanie osób trzecich do wywierania presji lub kontrolowania narracji.",
+        "tip": "Ogranicz pośrednie kanały i rozmawiaj tylko w bezpieczny sposób."
+      },
+      "loveBombing": {
+        "label": "Love bombing",
+        "description": "Zalew uczuć lub obietnic, by odzyskać kontrolę.",
+        "tip": "Zwracaj uwagę na stałe działania, a nie wielkie deklaracje."
+      },
+      "guiltTripping": {
+        "label": "Wzbudzanie poczucia winy",
+        "description": "Wywoływanie poczucia winy, by wymusić uległość.",
+        "tip": "Nazwij technikę i potwierdź swoje granice."
+      },
+      "futureFaking": {
+        "label": "Future faking",
+        "description": "Obiecywanie przyszłości, by zatrzymać cię przy sobie.",
+        "tip": "Skup się na tym, co dzieje się teraz, nie na obietnicach."
+      }
+    },
+    "responses": {
+      "welcome": "Ja przecież chcę dobrze. Powiedz, co ci chodzi po głowie.",
+      "gaslighting": {
+        "overreacting": "Znowu przesadzasz. Wszyscy wiedzą, że jesteś przewrażliwiona/y."
+      },
+      "blameShift": {
+        "yourFault": "To twoja wina — gdybyś zachowywał/a się lepiej, nie byłoby problemu."
+      },
+      "triangulation": {
+        "everyone": "Nawet znajomi mówią, że to z tobą najtrudniej."
+      },
+      "loveBombing": {
+        "promises": "Obiecuję, że zmienię się z dnia na dzień, tylko daj mi jeszcze jedną szansę."
+      },
+      "guiltTripping": {
+        "sacrifice": "Po tym wszystkim, co dla ciebie poświęciłem/am, tak się odwdzięczasz?"
+      },
+      "futureFaking": {
+        "plans": "Dlaczego się złościsz? Już zaplanowałem/am nasz dom i ślub."
+      },
+      "default": "Nie rób scen. Wymyślasz problemy."
+    },
+    "disclaimer": "Materiały edukacyjne. Symulator działa offline i nie wysyła twoich danych."
+  },
+  "rf": {
+    "title": "Dziennik Czerwonych Flag",
+    "add": "Dodaj incydent",
+    "date": "Data",
+    "category": "Kategoria",
+    "intensity": "Natężenie",
+    "note": "Opis (opcjonalnie)",
+    "export": "Eksportuj JSON",
+    "filter": {
+      "from": "Od",
+      "to": "Do",
+      "category": "Filtr kategorii",
+      "intensity": "Filtr natężenia",
+      "intensityValue": "Natężenie {{value}}/5",
+      "all": "Wszystkie"
+    },
+    "list": {
+      "title": "Lista wpisów"
+    },
+    "none": "Brak wpisów dla wybranych filtrów.",
+    "form": {
+      "dateError": "Wybierz datę.",
+      "limitError": "Opis może mieć maksymalnie {{max}} znaków.",
+      "submitError": "Nie udało się zapisać wpisu.",
+      "success": "Zapisano lokalnie",
+      "intensityValue": "Natężenie: {{value}}/5",
+      "limit": "Do {{max}} znaków.",
+      "submit": "Dodaj wpis"
+    },
+    "categories": {
+      "gaslighting": "Gaslighting",
+      "financial_abuse": "Przemoc ekonomiczna",
+      "stalking": "Stalking",
+      "legal_weaponization": "Wykorzystywanie prawa",
+      "emotional_blackmail": "Szantaż emocjonalny",
+      "devaluation": "Dewaluacja",
+      "discard": "Odrzucenie",
+      "hoovering": "Hoovering"
+    },
+    "calendar": {
+      "title": "Kalendarz miesięczny",
+      "subtitle": "Poruszaj się strzałkami, aby sprawdzić dni. Wpisy zostają tylko na tym urządzeniu.",
+      "prevMonth": "Poprzedni miesiąc",
+      "nextMonth": "Następny miesiąc",
+      "prevShort": "◀",
+      "nextShort": "▶",
+      "ariaLabel": "Kalendarz zarejestrowanych incydentów",
+      "week": {
+        "mon": "Poniedziałek",
+        "tue": "Wtorek",
+        "wed": "Środa",
+        "thu": "Czwartek",
+        "fri": "Piątek",
+        "sat": "Sobota",
+        "sun": "Niedziela",
+        "monShort": "Pn",
+        "tueShort": "Wt",
+        "wedShort": "Śr",
+        "thuShort": "Cz",
+        "friShort": "Pt",
+        "satShort": "So",
+        "sunShort": "Nd"
+      },
+      "dayAria": "{{date}}. Liczba wpisów: {{count}}.",
+      "count": "Wpisów: {{count}}"
+    }
   }
 }

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -1,14 +1,7 @@
-import { useTranslation } from 'react-i18next';
+import type { JSX } from 'react';
+
+import { CommunitySection } from '../features/community/CommunitySection';
 
 export default function Community(): JSX.Element {
-  const { t } = useTranslation();
-
-  return (
-    <section>
-      <h1 className="text-3xl font-bold text-base-50 sm:text-4xl">{t('pages.community.title')}</h1>
-      <p className="mt-4 max-w-2xl text-base-200">
-        Interactive community tooling is coming soon.
-      </p>
-    </section>
-  );
+  return <CommunitySection />;
 }


### PR DESCRIPTION
## Summary
- add accessible TabNav and confirm dialog primitives for the interactive area
- implement the community voices board with local persistence, moderation controls, and unit tests
- deliver the manipulator simulator plus red-flag journal with calendar, filters, storage, and i18n updates
- document local-only data policy and export instructions in the README

## Testing
- node node_modules/.bin/eslint src/components/ConfirmDialog.tsx src/components/TabNav.tsx src/components/TabNav.test.tsx src/features/community src/features/redflags src/features/simulator src/pages/Community.tsx --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68db1aecc118832285cb889d30a47b6d