### PR TITLE
Fix analysis archive API and tidy guides layout

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,10 @@ export default [
       parser: tsparser,
       parserOptions: {
         ecmaVersion: 'latest',
-        sourceType: 'module'
+        sourceType: 'module',
+        ecmaFeatures: {
+          jsx: true
+        }
       },
       globals: {
         ...globals.browser,
@@ -30,9 +33,27 @@ export default [
     rules: {
       ...js.configs.recommended.rules,
       ...tseslint.configs.recommended.rules,
+      'no-undef': 'off',
       'react-refresh/only-export-components': 'off',
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn'
+    }
+  }
+  ,
+  {
+    files: ['**/*.d.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off'
+    }
+  },
+  {
+    files: ['**/*.test.{ts,tsx}'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.vitest
+      }
     }
   }
 ];

--- a/src/features/analysis-archive/AnalysisPlayer.tsx
+++ b/src/features/analysis-archive/AnalysisPlayer.tsx
@@ -80,7 +80,7 @@ export const AnalysisPlayer = forwardRef<AnalysisPlayerHandle, AnalysisPlayerPro
       audio.removeEventListener('timeupdate', handleTime);
       audio.removeEventListener('ended', handleEnded);
     };
-  }, [episode?.id]);
+  }, [episode?.id, episode?.durationSec]);
 
   useEffect(() => {
     const audio = audioRef.current;
@@ -113,7 +113,7 @@ export const AnalysisPlayer = forwardRef<AnalysisPlayerHandle, AnalysisPlayerPro
       setDuration(0);
       setIsPlaying(false);
     }
-  }, [episode?.audioUrl, episode?.durationSec, episode?.id]);
+  }, [episode]);
 
   useEffect(() => {
     const audio = audioRef.current;

--- a/src/features/analysis-archive/__tests__/api.test.tsx
+++ b/src/features/analysis-archive/__tests__/api.test.tsx
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EpisodeQueryResult as BaseEpisodeQueryResult } from '../../../data/types';
+import type { EpisodeQueryResult } from '../data.schema';
+
+vi.mock('../../../data/episodes', () => ({
+  getEpisodes: vi.fn(),
+  getLocalEpisodes: vi.fn()
+}));
+
+type EpisodesModule = typeof import('../../../data/episodes');
+let episodesModule: vi.Mocked<EpisodesModule>;
+
+describe('analysis-archive/api', () => {
+  beforeEach(async () => {
+    episodesModule = vi.mocked(await import('../../../data/episodes'));
+    episodesModule.getEpisodes.mockReset();
+    episodesModule.getLocalEpisodes.mockReset();
+  });
+
+  it('adapts supabase results to the feature schema', async () => {
+    const response: BaseEpisodeQueryResult = {
+      episodes: [
+        {
+          id: 'episode-1',
+          title: 'Episode 1',
+          category: 'AktDarowania',
+          tags: ['a'],
+          description: 'desc',
+          durationSec: 120,
+          audioUrl: 'https://example.com/audio.mp3',
+          publishedAt: '2024-01-01T00:00:00.000Z',
+          coverUrl: undefined,
+          slug: undefined,
+          chapters: [],
+          resources: []
+        },
+        {
+          id: 'episode-2',
+          title: 'Episode 2',
+          category: 'Unknown',
+          tags: [],
+          description: 'desc',
+          durationSec: 60,
+          audioUrl: 'https://example.com/2.mp3',
+          publishedAt: '2024-02-01T00:00:00.000Z'
+        }
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 10,
+      metadata: {
+        categories: [
+          { value: 'AktDarowania', count: 5 },
+          { value: 'Unknown', count: 2 }
+        ],
+        tags: [{ value: 'a', count: 1 }]
+      }
+    };
+
+    episodesModule.getEpisodes.mockResolvedValue(response);
+
+    const { getEpisodes } = await import('../api');
+    const result = await getEpisodes({ categories: ['AktDarowania'] });
+
+    expect(episodesModule.getEpisodes).toHaveBeenCalledWith({ categories: ['AktDarowania'] });
+    expect(result).toEqual<EpisodeQueryResult>({
+      episodes: [
+        {
+          id: 'episode-1',
+          title: 'Episode 1',
+          category: 'AktDarowania',
+          tags: ['a'],
+          description: 'desc',
+          durationSec: 120,
+          audioUrl: 'https://example.com/audio.mp3',
+          publishedAt: '2024-01-01T00:00:00.000Z',
+          coverUrl: undefined,
+          slug: 'episode-1',
+          chapters: [],
+          resources: []
+        }
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 10,
+      metadata: {
+        categories: [{ value: 'AktDarowania', count: 5 }],
+        tags: [{ value: 'a', count: 1 }]
+      }
+    });
+  });
+
+  it('falls back to the local dataset when remote loading fails', async () => {
+    const fallback: BaseEpisodeQueryResult = {
+      episodes: [
+        {
+          id: 'episode-3',
+          title: 'Episode 3',
+          category: 'SłużebnośćUwiązania',
+          tags: [],
+          description: 'desc',
+          durationSec: 180,
+          audioUrl: 'https://example.com/3.mp3',
+          publishedAt: '2024-03-01T00:00:00.000Z'
+        }
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 10,
+      metadata: {
+        categories: [{ value: 'SłużebnośćUwiązania', count: 1 }],
+        tags: []
+      }
+    };
+
+    episodesModule.getEpisodes.mockRejectedValue(new Error('network error'));
+    episodesModule.getLocalEpisodes.mockResolvedValue(fallback);
+
+    const { getEpisodes } = await import('../api');
+    const result = await getEpisodes();
+
+    expect(episodesModule.getEpisodes).toHaveBeenCalled();
+    expect(episodesModule.getLocalEpisodes).toHaveBeenCalled();
+    expect(result.episodes[0]).toMatchObject({ id: 'episode-3', slug: 'episode-3' });
+  });
+});

--- a/src/features/analysis-archive/api.ts
+++ b/src/features/analysis-archive/api.ts
@@ -1,52 +1,5 @@
-import { getEpisodes as fetchEpisodes, getLocalEpisodes } from '../../data/episodes';
+import { getEpisodes as fetchEpisodes, getLocalEpisodes as fetchLocalEpisodes } from '../../data/episodes';
 import type {
-
-  Episode,
-  EpisodeCategory,
-  EpisodeFiltersMetadata,
-  EpisodeQuery,
-  EpisodeQueryResult,
-  EpisodeSort
-} from './data.schema';
-
-const LOCAL_EPISODES: Episode[] = (localEpisodes as Episode[]).map((episode) => ({
-  ...episode,
-  tags: episode.tags ?? []
-}));
-
-type SupabaseQueryResult = {
-  data: unknown;
-  error: unknown;
-  count: number | null;
-};
-
-type SupabaseQueryBuilder = {
-  select: (...args: unknown[]) => SupabaseQueryBuilderPromise;
-  in: (...args: unknown[]) => SupabaseQueryBuilder;
-  contains: (...args: unknown[]) => SupabaseQueryBuilder;
-  eq: (...args: unknown[]) => SupabaseQueryBuilder;
-  order: (...args: unknown[]) => SupabaseQueryBuilder;
-  range: (...args: unknown[]) => SupabaseQueryBuilder;
-};
-
-type SupabaseQueryBuilderPromise = SupabaseQueryBuilder & PromiseLike<SupabaseQueryResult>;
-
-type SupabaseClient = {
-  from: (table: string) => SupabaseQueryBuilder;
-};
-
-type CreateClientFn = (url: string, key: string, options?: Record<string, unknown>) => SupabaseClient;
-
-function getSupabaseConfig(): { url: string; key: string } | null {
-  const url = import.meta.env.VITE_SUPABASE_URL;
-  const key = import.meta.env.VITE_SUPABASE_ANON;
-
-  if (typeof url === 'string' && url.length > 0 && typeof key === 'string' && key.length > 0) {
-    return { url, key };
-  }
-
-  return null;
-
   Episode as BaseEpisode,
   EpisodeFiltersMetadata as BaseEpisodeFiltersMetadata,
   EpisodeQuery as BaseEpisodeQuery,
@@ -56,7 +9,7 @@ import type { Episode, EpisodeCategory, EpisodeFiltersMetadata, EpisodeQuery, Ep
 
 const CATEGORY_VALUES: EpisodeCategory[] = [
   'AktDarowania',
-  'SlużebnośćUwiązania',
+  'SłużebnośćUwiązania',
   'SprawaAdamskich',
   'BronNarcyza',
   'Sledztwo'
@@ -64,7 +17,6 @@ const CATEGORY_VALUES: EpisodeCategory[] = [
 
 function isEpisodeCategory(value: string): value is EpisodeCategory {
   return CATEGORY_VALUES.includes(value as EpisodeCategory);
-
 }
 
 function adaptEpisode(episode: BaseEpisode): Episode | null {
@@ -77,11 +29,25 @@ function adaptEpisode(episode: BaseEpisode): Episode | null {
     ...episode,
     slug: episode.slug ?? episode.id,
     category: episode.category,
-    chapters: episode.chapters?.map((chapter) => ({ title: chapter.title, startSec: chapter.startSec }))
+    tags: episode.tags ?? [],
+    description: episode.description,
+    durationSec: episode.durationSec,
+    audioUrl: episode.audioUrl,
+    coverUrl: episode.coverUrl,
+    publishedAt: episode.publishedAt
   };
 }
 
-function adaptEpisodesResult(result: BaseEpisodeQueryResult): EpisodeQueryResult {
+function adaptMetadata(metadata: BaseEpisodeFiltersMetadata): EpisodeFiltersMetadata {
+  return {
+    categories: metadata.categories
+      .filter((category): category is { value: EpisodeCategory; count: number } => isEpisodeCategory(category.value))
+      .map((category) => ({ value: category.value as EpisodeCategory, count: category.count })),
+    tags: metadata.tags
+  };
+}
+
+function adaptQueryResult(result: BaseEpisodeQueryResult): EpisodeQueryResult {
   const episodes = result.episodes
     .map(adaptEpisode)
     .filter((episode): episode is Episode => episode !== null);
@@ -95,142 +61,25 @@ function adaptEpisodesResult(result: BaseEpisodeQueryResult): EpisodeQueryResult
   };
 }
 
-
-function filterByProgram(episode: Episode, programId?: EpisodeQuery['programId']): boolean {
-  if (!programId) {
-    return true;
-  }
-
-  return episode.programId === programId;
-}
-
-function getLocalEpisodes(query: EpisodeQuery = {}): EpisodeQueryResult {
-  const { q, categories, tags, sort, page, pageSize, programId } = getDefaultedQuery(query);
-
-  const metadata = computeMetadata(LOCAL_EPISODES);
-
-  const filtered = LOCAL_EPISODES.filter((episode) => {
-    const matchesSearch = q ? matchesQuery(episode, q) : true;
-    return (
-      matchesSearch &&
-      filterByCategories(episode, categories) &&
-      filterByTags(episode, tags) &&
-      filterByProgram(episode, programId)
-    );
-  });
-
-  const sorted = sortEpisodes(filtered, sort);
-  const paged = paginate(sorted, page, pageSize);
-function adaptMetadata(metadata: BaseEpisodeFiltersMetadata): EpisodeFiltersMetadata {
-  const categories = metadata.categories
-    .filter((category) => isEpisodeCategory(category.value))
-    .map((category) => ({ value: category.value as EpisodeCategory, count: category.count }));
-
-
-  return {
-    categories,
-    tags: metadata.tags
-  };
-}
-
-
-function escapeLikeValue(value: string): string {
-  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
-}
-
-async function getSupabaseMetadata(client: SupabaseClient): Promise<EpisodeFiltersMetadata> {
-  const { data, error } = await client.from('episodes').select('category,tags');
-
-  if (error) {
-    throw error;
-  }
-
-  const mapped: Episode[] = (data ?? []).map((item) => ({
-    id: '',
-    title: '',
-    slug: '',
-    category: item.category as EpisodeCategory,
-    tags: (item.tags as string[]) ?? [],
-    description: '',
-    durationSec: 0,
-    audioUrl: '',
-    publishedAt: new Date().toISOString()
-  }));
-
-  return computeMetadata(mapped);
-}
-
-async function getSupabaseEpisodes(client: SupabaseClient, query: EpisodeQuery = {}): Promise<EpisodeQueryResult> {
-  const { q, categories, tags, sort, page, pageSize, programId } = getDefaultedQuery(query);
-
-  let builder = client.from('episodes').select('*', { count: 'exact' });
-
-  if (q) {
-    const escaped = escapeLikeValue(q.trim());
-    builder = builder.or(`title.ilike.%${escaped}%,description.ilike.%${escaped}%`);
-  }
-
-  if (categories && categories.length > 0) {
-    builder = builder.in('category', categories);
-  }
-
-  if (tags && tags.length > 0) {
-    builder = builder.contains('tags', tags);
-  }
-
-  if (programId) {
-    builder = builder.eq('program_id', programId);
-  }
-
-  switch (sort) {
-    case 'oldest':
-      builder = builder.order('publishedAt', { ascending: true });
-      break;
-    case 'durationAsc':
-      builder = builder.order('durationSec', { ascending: true });
-      break;
-    case 'durationDesc':
-      builder = builder.order('durationSec', { ascending: false });
-      break;
-    case 'newest':
-    default:
-      builder = builder.order('publishedAt', { ascending: false });
-      break;
-  }
-
-  const rangeStart = (page - 1) * pageSize;
-  const rangeEnd = rangeStart + pageSize - 1;
-  builder = builder.range(rangeStart, rangeEnd);
-
-  const [{ data, error, count }, metadata] = await Promise.all([
-    builder,
-    getSupabaseMetadata(client)
-  ]);
-
-  if (error) {
-    throw error;
-  }
-
-  return {
-    episodes: (data as Episode[]) ?? [],
-    total: count ?? 0,
-    page,
-    pageSize,
-    metadata
-  };
-
 function toBaseQuery(query: EpisodeQuery): BaseEpisodeQuery {
-  return { ...query } as BaseEpisodeQuery;
+  const { categories, programId: _programId, ...rest } = query;
+  void _programId;
 
+  return {
+    ...rest,
+    categories: categories?.map((category) => category)
+  };
 }
 
 export async function getEpisodes(query: EpisodeQuery = {}): Promise<EpisodeQueryResult> {
+  const baseQuery = toBaseQuery(query);
+
   try {
-    const result = await fetchEpisodes(toBaseQuery(query));
-    return adaptEpisodesResult(result);
+    const result = await fetchEpisodes(baseQuery);
+    return adaptQueryResult(result);
   } catch (error) {
-    console.warn('[analysis-archive] Failed to load data from Supabase, falling back to local JSON.', error);
-    const fallback = await getLocalEpisodes(toBaseQuery(query));
-    return adaptEpisodesResult(fallback);
+    console.warn('[analysis-archive] Falling back to local dataset due to fetch failure.', error);
+    const fallback = await fetchLocalEpisodes(baseQuery);
+    return adaptQueryResult(fallback);
   }
 }

--- a/src/features/analysis-archive/data.schema.ts
+++ b/src/features/analysis-archive/data.schema.ts
@@ -18,7 +18,7 @@ export type Chapter = {
 
 export type EpisodeCategory =
   | 'AktDarowania'
-  | 'SlużebnośćUwiązania'
+  | 'SłużebnośćUwiązania'
   | 'SprawaAdamskich'
   | 'BronNarcyza'
   | 'Sledztwo';

--- a/src/features/whisper/WhisperSection.tsx
+++ b/src/features/whisper/WhisperSection.tsx
@@ -152,7 +152,6 @@ export function WhisperSection(): JSX.Element {
     } catch (error) {
       // Playback may be blocked by the browser until user interaction.
       setStatusMessage(t('whisper.status.error'));
-      // eslint-disable-next-line no-console
       console.error('Unable to play the audio file.', error);
     }
   }, [isPlaying, t]);
@@ -172,7 +171,6 @@ export function WhisperSection(): JSX.Element {
         await audio.play();
       } catch (error) {
         setStatusMessage(t('whisper.status.error'));
-        // eslint-disable-next-line no-console
         console.error('Unable to resume playback.', error);
       }
     }

--- a/src/pages/Guides.tsx
+++ b/src/pages/Guides.tsx
@@ -1,18 +1,15 @@
 
-import { EightSinsPage } from '../features/guide-eight-sins/EightSinsPage';
-
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
+import { EightSinsPage } from '../features/guide-eight-sins/EightSinsPage';
 import { LibrarySection } from '../features/library/LibrarySection';
 import { MythologySection } from '../features/mythology/MythologySection';
 
 export default function Guides(): JSX.Element {
+  const { t } = useTranslation();
+
   return (
-
-    <section className="space-y-6">
-      <EightSinsPage />
-
     <section className="space-y-12">
       <header className="space-y-6">
         <div className="space-y-4">
@@ -21,10 +18,7 @@ export default function Guides(): JSX.Element {
           </h1>
           <p className="max-w-3xl text-base text-base-200">{t('pages.guides.lede')}</p>
         </div>
-        <nav
-          aria-label={t('pages.guides.anchorNav')}
-          className="flex flex-wrap gap-3"
-        >
+        <nav aria-label={t('pages.guides.anchorNav')} className="flex flex-wrap gap-3">
           <a
             href="#library"
             className="inline-flex items-center gap-2 rounded-full border border-accent-500/50 bg-base-925/60 px-4 py-2 text-sm font-semibold text-accent-100 transition motion-safe:hover:border-accent-400 motion-safe:hover:text-accent-50 focus-visible:shadow-focus"
@@ -45,25 +39,18 @@ export default function Guides(): JSX.Element {
       <div className="space-y-12">
         <LibrarySection sectionId="library" />
         <MythologySection sectionId="mythology" />
-    <section className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold text-base-50 sm:text-4xl">{t('pages.guides.title')}</h1>
-        <p className="mt-4 max-w-2xl text-base-200">
-          Guidance and educational modules will appear here.
-        </p>
+        <EightSinsPage />
+        <div className="rounded-2xl border border-base-800 bg-base-900/40 p-6 text-base-100">
+          <h2 className="text-xl font-semibold text-accent-300">{t('analysis.page.title')}</h2>
+          <p className="mt-2 text-sm text-base-300">{t('analysis.page.lead')}</p>
+          <Link
+            to="/analysis"
+            className="mt-4 inline-flex items-center justify-center rounded-full border border-accent-400 px-5 py-2 text-sm font-semibold text-accent-200 transition hover:bg-accent-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400"
+          >
+            {t('analysis.actions.listen')}
+          </Link>
+        </div>
       </div>
-
-      <div className="rounded-2xl border border-base-800 bg-base-900/40 p-6 text-base-100">
-        <h2 className="text-xl font-semibold text-accent-300">{t('analysis.page.title')}</h2>
-        <p className="mt-2 text-sm text-base-300">{t('analysis.page.lead')}</p>
-        <Link
-          to="/analysis"
-          className="mt-4 inline-flex items-center justify-center rounded-full border border-accent-400 px-5 py-2 text-sm font-semibold text-accent-200 transition hover:bg-accent-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-400"
-        >
-          {t('analysis.actions.listen')}
-        </Link>
-      </div>
-
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- restore the analysis archive API by removing stale Supabase scaffolding, adapting results to the feature schema, and adding a fallback to the local dataset
- extend the ESLint setup to recognise JSX/Vitest contexts and add a regression test covering the new API behaviour alongside minor player/whisper fixes
- clean up the guides page structure while keeping translations and accessibility intact

## Testing
- node_modules/.bin/eslint . --max-warnings=0
- node_modules/.bin/vitest run *(fails: missing jsdom dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68dc46b83f048322b65c2cd23842ef1e